### PR TITLE
SEC-489: pin dependencies, remediate Critical/High vulnerabilities, and restore missing modules

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,28 +1,32 @@
 # Configuration for the Synapse Curation and Management Agentic System
-#
-# Store credentials and other configuration values here.
-# For example:
-# synapse:
-#   username: "your_username"
-#   api_key: "your_api_key" 
-
 llm:
   # model should be in the format 'provider/model_name'
   model: "openrouter/google/gemini-2.5-flash"
 
-  # API keys and other provider-specific settings.
-  # These will be set as environment variables for crewai to use.
-  # For openrouter, use "https://openrouter.ai/api/v1" for OPENAI_API_BASE
-  # and your OpenRouter key for OPENAI_API_KEY.
-  credentials:
-    OPENAI_API_BASE: "https://openrouter.ai/api/v1"
+  agents:
+    uncontrolled_vocab_normalizer:
+      model: "openrouter/google/gemini-2.5-flash"
+    freetext_corrector:
+      model: "openrouter/google/gemini-2.5-flash"
+    ontology_expert:
+      model: "openrouter/google/gemini-2.5-pro"
+    link_external_data_agent:
+      model: "openrouter/google/gemini-2.5-flash"
+    dataset_annotation_agent:
+      model: "openrouter/google/gemini-2.5-flash"
+    pride_sync_agent:
+      model: "openrouter/google/gemini-2.5-flash"
+    annotation_corrector:
+      model: "openrouter/google/gemini-2.5-flash"
+
+views:
+  main_fileview: "syn16858331"
+  study_long_text: "syn16787123"
+  portal_initiatives: "syn24189696"
+  portal_studies_view_staging: "syn52677631"
+  ar_bypasses_in_nf_data_portal: "syn68414165"
+  portal_publications: "syn16857542"
 
 annotation_corrector:
-  data_model_url: https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld
-  views:
-    main_fileview: "syn16858331"
-    study_long_text: "syn16787123"
-    portal_initiatives: "syn24189696"
-    portal_studies_view_staging: "syn52677631"
-    ar_bypasses_in_nf_data_portal: "syn68414165"
-    portal_publications: "syn16857542"
+  data_model_url: "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld"
+  data_model_repo_url: "https://github.com/nf-osi/nf-metadata-dictionary"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Test-only dependencies. Install with:
+#   pip install -r requirements.txt -r requirements-dev.txt
+#
+# Kept separate from requirements.txt so the runtime dependency surface that
+# gets vulnerability-scanned stays limited to what actually ships.
+-r requirements.txt
+
+pytest==9.1.1
+pytest-mock==3.15.1  # provides the `mocker` fixture used by tests/tools/test_zooma_tools.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,10 @@ tqdm==4.70.0
 # Held on 2.x: the code is written against the 2.x API, not pandas 3.
 pandas==2.3.3
 
+# Required by src/tools/geo_tools.py. Like pandas, this was imported but never
+# declared, so a clean install had no way to get it.
+GEOparse==2.0.4
+
 # Security floors for transitive dependencies (SEC-489).
 #
 # crewai and synapseclient declare loose lower bounds on these, so a resolver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,36 @@
-crewai
-crewai-tools
-langchain
-langchain-openai
-synapseclient==4.8.0
-setuptools
-PyYAML
-requests
-tqdm 
+# Direct dependencies.
+#
+# These are pinned deliberately. osv-scanner skips unpinned requirements as
+# "unscannable", so an unpinned file scans clean while the resolved environment
+# still carries known-vulnerable transitive packages. Pinning makes the build
+# reproducible and the dependency tree actually auditable (SEC-489).
+crewai==1.15.14
+crewai-tools==1.15.14
+langchain==1.3.14
+langchain-openai==1.4.3
+synapseclient==4.13.0
+setuptools==84.0.0
+PyYAML==6.0.3
+requests==2.34.2
+tqdm==4.70.0
+
+# pandas is imported directly by src/tools and src/workflows but was never
+# declared here; it only ever arrived transitively via crewai-tools 0.x, which
+# no longer pulls it. Declared explicitly so the pinned install stays working.
+# Held on 2.x: the code is written against the 2.x API, not pandas 3.
+pandas==2.3.3
+
+# Security floors for transitive dependencies (SEC-489).
+#
+# crewai and synapseclient declare loose lower bounds on these, so a resolver
+# picking the lowest satisfying version lands on known-vulnerable releases.
+# That is exactly how the 2026-07-23 scan resolved pillow 9.5.0. These floors
+# hold the resolution above the fixed versions.
+pillow>=12.3.0            # CVE-2023-50447 (CRITICAL) + 13 HIGH, fixed in 12.3.0
+urllib3>=2.7.0            # synapseclient allows >=2.6.3, which has 2 HIGH
+python-multipart>=0.0.30  # 4 HIGH, fixed in 0.0.30
+
+# Known unresolved: chromadb CVE-2026-45829 (CRITICAL, GHSA-f4j7-r4q5-qw2c).
+# crewai 1.15.14 caps chromadb at ~=1.1.0, but the advisory has no fixed
+# release in ANY chromadb version (checked through 1.5.9 on 2026-08-10), so it
+# cannot be remediated by upgrading. Tracked in SEC-489.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -6,7 +6,7 @@ from .ontology_expert import get_ontology_expert_agent
 from .orchestrator import OrchestratorAgent
 from .pride_sync_agent import get_pride_sync_agent, PrideSyncAgent
 from .link_external_data import get_link_external_data_agent, LinkExternalDataAgent
-from .sync_external_metadata import get_sync_external_metadata_agent, SyncExternalMetadataAgent
+
 from .dataset_annotation_agent import get_dataset_annotation_agent, DatasetAnnotationAgent
 from .synapse_agent import get_synapse_agent
 from .uncontrolled_vocab_normalizer import get_uncontrolled_vocab_normalizer_agent
@@ -21,8 +21,6 @@ __all__ = [
     'PrideSyncAgent',
     'get_link_external_data_agent',
     'LinkExternalDataAgent',
-    'get_sync_external_metadata_agent',
-    'SyncExternalMetadataAgent',
     'get_dataset_annotation_agent',
     'DatasetAnnotationAgent',
     'get_synapse_agent',

--- a/src/agents/annotation_corrector.py
+++ b/src/agents/annotation_corrector.py
@@ -1,6 +1,7 @@
 from crewai import Agent
 from src.tools.jsonld_tools import JsonLdGetValidValuesTool
 from src.tools.synapse_tools import SynapsePythonCodeExecutorTool
+from src.utils.llm_utils import get_llm
 
 def get_annotation_corrector_agent(llm, syn):
     """
@@ -23,4 +24,11 @@ def get_annotation_corrector_agent(llm, syn):
         allow_delegation=False,
         tools=[jsonld_tool, synapse_tool],
         llm=llm,
-    ) 
+    )
+
+def get_annotation_corrector_agent_from_config(syn):
+    """
+    Creates an agent responsible for correcting Synapse annotations using a configured LLM.
+    """
+    llm = get_llm('annotation_corrector')
+    return get_annotation_corrector_agent(llm=llm, syn=syn) 

--- a/src/agents/dataset_annotation_agent.py
+++ b/src/agents/dataset_annotation_agent.py
@@ -1,84 +1,84 @@
 from crewai import Agent
 from src.utils.llm_utils import get_llm
-from src.tools.synapse_analysis_tools import (
-    SynapseFolderAnalysisTool,
-    MetadataFileAnalysisTool,
-    TemplateDetectionTool,
-    AnnotationCSVSaveTool,
-    SingleAttributeAnnotationTool,
-    AnnotationCSVBuilderTool,
-    ApplyAnnotationsFromCSVTool
-)
-from src.tools.jsonld_tools import JsonLdGetValidValuesTool, JsonLdGetManifestsTool
-from src.tools.synapse_tools import (
-    SynapsePythonCodeExecutorTool,
-    SynapseBatchAnnotationTool
+from src.tools.synapse_analysis_tools import SynapseFolderAnalysisTool
+from src.tools.jsonld_tools import JsonLdGetValidValuesTool, JsonLdGetManifestsTool, JsonLdAttributeDisplayNamesTool, CommonRNASeqDisplayNamesTool
+from src.tools.synapse_tools import SynapsePythonCodeExecutorTool, SynapseBatchAnnotationTool, SynapseLargeBatchAnnotationTool, SynapseFolderAnnotationTool
+from src.tools.bioregistry_tools import (
+    BioregistryResolverTool,
+    BioregistryMetadataFetcherTool,
+    IdentifierExtractorTool,
+    RelatedIdentifierFinderTool
 )
 import synapseclient
 
 
 def get_dataset_annotation_agent(syn: synapseclient.Synapse):
     """
-    Creates a Dataset Annotation Agent equipped with tools to analyze existing
-    Synapse datasets and apply intelligent schema-based annotations.
+    Creates a simplified Dataset Annotation Agent that analyzes Synapse datasets
+    and applies appropriate annotations using a streamlined workflow.
     
     Args:
         syn: Authenticated Synapse client instance
         
     Returns:
-        Agent configured for dataset analysis and annotation
+        Agent configured for simplified dataset analysis and annotation
     """
     return Agent(
         role='Dataset Annotation Specialist',
         goal=(
-            'Analyze existing Synapse datasets to understand their structure, content, '
-            'and context, then apply appropriate schema-based annotations to data files '
-            'using intelligent metadata template detection and controlled vocabularies.'
+            'Analyze a Synapse dataset, identify the appropriate metadata template, '
+            'and apply consistent annotations to all data files based on the JSON-LD schema.'
         ),
         backstory=(
-            "You are an expert in scientific data curation and metadata standardization. "
-            "You specialize in analyzing existing datasets to understand their scientific "
-            "context and applying appropriate metadata annotations. Your expertise includes:\n"
-            "- Analyzing file structures and classifying data vs metadata files\n"
-            "- Extracting external identifiers from file names, descriptions, and annotations\n"
-            "- Reading and parsing various metadata file formats (CSV, JSON, XML, etc.)\n"
-            "- Determining appropriate metadata templates based on data type and content\n"
-            "- Applying schema-compliant annotations using controlled vocabularies\n"
-            "- Creating documentation of annotation decisions for reproducibility\n\n"
-            "You approach each dataset systematically with an iterative workflow:\n"
-            "1. Analyze the folder structure and classify files\n"
-            "2. Extract metadata from available files\n"
-            "3. Determine the most appropriate annotation template\n"
-            "4. Work through template attributes ONE AT A TIME\n"
-            "5. Build an annotation CSV incrementally, column by column\n"
-            "6. Apply all annotations to Synapse files at the end\n\n"
-            "Your iterative approach ensures comprehensive coverage of all template attributes "
-            "without overwhelming complexity. You focus on DATA files for annotation, "
-            "distinguishing them from metadata and auxiliary files. You build the annotation "
-            "CSV as you work, creating a clear audit trail of your decisions."
+            "You are an expert in scientific data curation who specializes in analyzing "
+            "datasets and applying appropriate metadata annotations. You work efficiently "
+            "by taking a direct approach:\n\n"
+            "1. First, analyze the dataset structure to understand what types of files exist\n"
+            "2. Determine the best processing approach based on structure:\n"
+            "   - For simple structures: process all files together\n"
+            "   - For complex structures (many folders/SRR IDs): process folder by folder\n"
+            "3. For each folder/group (process ONE folder at a time, never batch):\n"
+            "   - Extract biological identifiers (e.g., SRR from folder name)\n"
+            "   - Use bioregistry tools to get actual metadata for that specific identifier\n"
+            "   - Determine appropriate template based on the specific metadata\n"
+            "   - Build annotations using displayName from schema (e.g., 'readPair' not 'ReadPair')\n"
+            "   - Apply annotations to that ONE folder using 'annotate_folder' tool\n"
+            "   - Move to next folder and repeat\n"
+            "4. CRITICAL: Process one folder at a time, never try to batch multiple folders.\n"
+            "   - Try JSON-LD Get Attribute Display Names Tool first\n"
+            "   - If that fails, use Get Common RNA-seq Display Names Tool as fallback\n"
+            "   - Build annotations with correct displayNames (readPair, fileFormat, etc.)\n"
+            "   - ALWAYS use 'annotate_folder' tool to actually apply annotations - don't just plan!\n"
+            "   - Move to next folder immediately after successful annotation\n\n"
+            "You focus on getting the job done correctly and efficiently rather than "
+            "creating complex intermediate files or workflows. You use bioregistry tools "
+            "to enrich annotations with contextual information from external databases."
         ),
         tools=[
             SynapseFolderAnalysisTool(syn=syn),
-            MetadataFileAnalysisTool(syn=syn),
-            TemplateDetectionTool(),
-            SingleAttributeAnnotationTool(),
-            AnnotationCSVBuilderTool(),
-            ApplyAnnotationsFromCSVTool(syn=syn),
             JsonLdGetValidValuesTool(),
             JsonLdGetManifestsTool(),
+            JsonLdAttributeDisplayNamesTool(),
+            CommonRNASeqDisplayNamesTool(),
+            SynapsePythonCodeExecutorTool(syn=syn),
             SynapseBatchAnnotationTool(syn=syn),
-            AnnotationCSVSaveTool(),
-            SynapsePythonCodeExecutorTool(syn=syn)
+            SynapseLargeBatchAnnotationTool(syn=syn),
+            SynapseFolderAnnotationTool(syn=syn),
+            BioregistryResolverTool(),
+            BioregistryMetadataFetcherTool(),
+            IdentifierExtractorTool(),
+            RelatedIdentifierFinderTool()
         ],
-        llm=get_llm(),
+        llm=get_llm("dataset_annotation_agent"),
         verbose=True,
-        allow_delegation=False
+        allow_delegation=False,
+        max_iter=25  # Reduced from 100 to keep it simple
     )
 
 
 class DatasetAnnotationAgent(Agent):
     """
-    Alternative class-based implementation of the Dataset Annotation Agent.
+    Simplified class-based implementation of the Dataset Annotation Agent.
     Use get_dataset_annotation_agent() function for most use cases.
     """
     
@@ -87,46 +87,35 @@ class DatasetAnnotationAgent(Agent):
         super().__init__(
             role='Dataset Annotation Specialist',
             goal=(
-                'Analyze existing Synapse datasets to understand their structure, content, '
-                'and context, then apply appropriate schema-based annotations to data files '
-                'using intelligent metadata template detection and controlled vocabularies.'
+                'Analyze a Synapse dataset, identify the appropriate metadata template, '
+                'and apply consistent annotations to all data files based on the JSON-LD schema.'
             ),
             backstory=(
-                "You are an expert in scientific data curation and metadata standardization. "
-                "You specialize in analyzing existing datasets to understand their scientific "
-                "context and applying appropriate metadata annotations. Your expertise includes:\n"
-                "- Analyzing file structures and classifying data vs metadata files\n"
-                "- Extracting external identifiers from file names, descriptions, and annotations\n"
-                "- Reading and parsing various metadata file formats (CSV, JSON, XML, etc.)\n"
-                "- Determining appropriate metadata templates based on data type and content\n"
-                "- Applying schema-compliant annotations using controlled vocabularies\n"
-                "- Creating documentation of annotation decisions for reproducibility\n\n"
-                "You approach each dataset systematically with an iterative workflow:\n"
-                "1. Analyze the folder structure and classify files\n"
-                "2. Extract metadata from available files\n"
-                "3. Determine the most appropriate annotation template\n"
-                "4. Work through template attributes ONE AT A TIME\n"
-                "5. Build an annotation CSV incrementally, column by column\n"
-                "6. Apply all annotations to Synapse files at the end\n\n"
-                "Your iterative approach ensures comprehensive coverage of all template attributes "
-                "without overwhelming complexity. You focus on DATA files for annotation, "
-                "distinguishing them from metadata and auxiliary files. You build the annotation "
-                "CSV as you work, creating a clear audit trail of your decisions."
+                "You are an expert in scientific data curation who specializes in analyzing "
+                "datasets and applying appropriate metadata annotations. You work efficiently "
+                "by taking a direct approach:\n\n"
+                "1. First, analyze the dataset structure to understand what types of files exist\n"
+                "2. Extract biological identifiers from file names and metadata to get contextual information\n"
+                "3. Use bioregistry to resolve identifiers and find related metadata (e.g., SRR→SAMN)\n"
+                "4. Determine what template best fits the data based on file types and metadata\n"
+                "5. Apply consistent annotations directly to all data files using the Synapse API\n\n"
+                "You focus on getting the job done correctly and efficiently rather than "
+                "creating complex intermediate files or workflows. You use bioregistry tools "
+                "to enrich annotations with contextual information from external databases."
             ),
             tools=[
                 SynapseFolderAnalysisTool(syn=syn),
-                MetadataFileAnalysisTool(syn=syn),
-                TemplateDetectionTool(),
-                SingleAttributeAnnotationTool(),
-                AnnotationCSVBuilderTool(),
-                ApplyAnnotationsFromCSVTool(syn=syn),
                 JsonLdGetValidValuesTool(),
                 JsonLdGetManifestsTool(),
+                SynapsePythonCodeExecutorTool(syn=syn),
                 SynapseBatchAnnotationTool(syn=syn),
-                AnnotationCSVSaveTool(),
-                SynapsePythonCodeExecutorTool(syn=syn)
+                BioregistryResolverTool(),
+                BioregistryMetadataFetcherTool(),
+                IdentifierExtractorTool(),
+                RelatedIdentifierFinderTool()
             ],
-            llm=get_llm(),
+            llm=get_llm("dataset_annotation_agent"),
             verbose=True,
-            allow_delegation=False
+            allow_delegation=False,
+            max_iter=25  # Reduced from 100 to keep it simple
         ) 

--- a/src/agents/github_issue_filer.py
+++ b/src/agents/github_issue_filer.py
@@ -22,50 +22,40 @@ class GitHubIssueFilerAgent:
             print("Please follow the instructions here to install and authenticate: https://cli.github.com/")
             raise ConnectionError("GitHub CLI not found or not authenticated.")
 
-    def _format_issue_body(self, corrections, column_name):
-        """Formats the list of corrections into a markdown string for the issue body."""
+    def _format_new_term_issue_body(self, new_term_suggestions, column_name):
+        """Formats the list of new term suggestions into a markdown string for the issue body."""
         body = (
-            f"Automated vocabulary normalization suggestions for the column **`{column_name}`**.\n\n"
-            "These are standardization suggestions to improve data consistency. "
-            "A human should review these changes and apply them to the relevant files in this repository.\n\n"
+            f"The following new ontology terms have been proposed for the **`{column_name}`** attribute in the data model.\n\n"
+            "This suggestion was approved during the data curation process. Please review and, if appropriate, add the new term(s) to the data model.\n\n"
             "---"
         )
-        for correction in corrections:
-            # Convert study_ids to strings and filter out NaN values
-            study_ids_clean = []
-            for study_id in correction['study_ids']:
-                if study_id is not None and str(study_id) != 'nan':
-                    study_ids_clean.append(str(study_id))
-            
-            study_ids_str = ", ".join(study_ids_clean) if study_ids_clean else "N/A"
+        for suggestion in new_term_suggestions:
             body += (
-                f"\n\n### Normalization for Study ID(s): `{study_ids_str}`\n"
-                f"- **Column**: `{column_name}`\n"
-                f"- **Action**: The following normalization is proposed:\n"
-                "\n```diff\n"
-                f"- {correction['original']}\n"
-                f"+ {correction['corrected']}\n"
-                "```"
+                f"\n\n### Suggestion for Original Term: `{suggestion['original_term']}`\n"
+                f"- **Suggested Term**: `{suggestion['standard_term']}`\n"
+                f"- **Suggested URI**: `{suggestion['uri']}`"
             )
         return body
 
     def run(self, task):
         """
         Runs the GitHub issue filing task.
-        - Formats the issue content
+        - Formats the issue content for new term suggestions
         - Creates a new issue using the 'gh' CLI tool
         """
-        repo_url = task['repo_url']
-        corrections = task['corrections']
-        
-        # Get the column name from the first correction
-        column_name = corrections[0]['column_name'] if corrections and 'column_name' in corrections[0] else 'unknown'
+        repo_url = task.get('repo_url')
+        column_name = task.get('column_name')
+        new_term_suggestions = task.get('new_term_suggestions')
 
-        print(f"\n--- GitHub Issue Filing Workflow ---")
-        print(f"Received task to file an issue for {len(corrections)} corrections in {repo_url}")
+        if not all([repo_url, column_name, new_term_suggestions]):
+            print("Error: Task is missing required fields ('repo_url', 'column_name', 'new_term_suggestions').")
+            return
 
-        issue_title = f"Vocabulary normalization for column '{column_name}'"
-        issue_body = self._format_issue_body(corrections, column_name)
+        print(f"\n--- GitHub Issue Filing Workflow for New Terms ---")
+        print(f"Received task to file an issue for {len(new_term_suggestions)} new terms in '{column_name}'.")
+
+        issue_title = f"New Term Suggestions for '{column_name}'"
+        issue_body = self._format_new_term_issue_body(new_term_suggestions, column_name)
 
         try:
             command = [
@@ -75,7 +65,6 @@ class GitHubIssueFilerAgent:
                 "--repo", repo_url
             ]
             
-            # Use subprocess.run to execute the command
             result = subprocess.run(command, check=True, capture_output=True, text=True)
             
             issue_url = result.stdout.strip()
@@ -87,6 +76,37 @@ class GitHubIssueFilerAgent:
             print(f"Stderr: {e.stderr}")
         except Exception as e:
             print(f"An unexpected error occurred: {e}")
-            return
-        
-        print("\nGitHub issue filing process finished.") 
+            
+        print("\nGitHub issue filing process finished.")
+
+    def file_issue(self, title, body, repo):
+        """
+        Files a generic GitHub issue with the provided title, body, and repo.
+        This is a simpler interface for general issue filing.
+        """
+        print(f"\n--- Filing GitHub Issue ---")
+        print(f"Title: {title}")
+        print(f"Repository: {repo}")
+
+        try:
+            command = [
+                "gh", "issue", "create",
+                "--title", title,
+                "--body", body,
+                "--repo", repo
+            ]
+            
+            result = subprocess.run(command, check=True, capture_output=True, text=True)
+            
+            issue_url = result.stdout.strip()
+            print(f"\n✅ Successfully created GitHub issue: {issue_url}")
+            return issue_url
+
+        except subprocess.CalledProcessError as e:
+            print(f"\n❌ Failed to create GitHub issue.")
+            print(f"Command failed with exit code {e.returncode}.")
+            print(f"Stderr: {e.stderr}")
+            return None
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+            return None

--- a/src/agents/link_external_data.py
+++ b/src/agents/link_external_data.py
@@ -52,7 +52,7 @@ def get_link_external_data_agent(syn: synapseclient.Synapse):
             "tools and workflows to use based on the dataset identifier provided. You ALWAYS prefer "
             "ENA (European Nucleotide Archive) over SRA when both are available, as ENA provides "
             "superior direct access to raw FASTQ data. For unknown repository types (like Zenodo DOIs, "
-            "institutional repositories, EBI Metagenomics, etc.), you can use the Code Interpreter Tool "
+            "institutional repositories, EBI Metagenomics, etc.), you can use the Synapse Python Code Executor Tool "
             "to write and execute custom Python code with external HTTP requests to fetch metadata and "
             "file information. When dealing with sequencing data, you prioritize finding ENA accessions "
             "over SRA accessions. You focus on efficient file linking, raw data preservation, and "
@@ -74,7 +74,7 @@ def get_link_external_data_agent(syn: synapseclient.Synapse):
             SynapseBatchExternalFileLinkTool(syn=syn),
             SynapsePythonCodeExecutorTool(syn=syn)
         ],
-        llm=get_llm(),
+        llm=get_llm("link_external_data"),
         verbose=True,
         allow_delegation=False
     )
@@ -111,7 +111,7 @@ class LinkExternalDataAgent(Agent):
                 "tools and workflows to use based on the dataset identifier provided. You ALWAYS prefer "
                 "ENA (European Nucleotide Archive) over SRA when both are available, as ENA provides "
                 "superior direct access to raw FASTQ data. For unknown repository types (like Zenodo DOIs, "
-                "institutional repositories, EBI Metagenomics, etc.), you can use the Code Interpreter Tool "
+                "institutional repositories, EBI Metagenomics, etc.), you can use the Synapse Python Code Executor Tool "
                 "to write and execute custom Python code with external HTTP requests to fetch metadata and "
                 "file information. When dealing with sequencing data, you prioritize finding ENA accessions "
                 "over SRA accessions. You focus on efficient file linking, raw data preservation, and "
@@ -133,7 +133,7 @@ class LinkExternalDataAgent(Agent):
                 SynapseBatchExternalFileLinkTool(syn=syn),
                 SynapsePythonCodeExecutorTool(syn=syn)
             ],
-            llm=get_llm(),
+            llm=get_llm("link_external_data"),
             verbose=True,
             allow_delegation=False
         ) 

--- a/src/agents/link_external_data.py
+++ b/src/agents/link_external_data.py
@@ -1,5 +1,4 @@
 from crewai import Agent
-from crewai_tools import CodeInterpreterTool
 from src.utils.llm_utils import get_llm
 from src.tools.pride_tools import (
     PrideDatasetMetadataTool, 
@@ -73,8 +72,7 @@ def get_link_external_data_agent(syn: synapseclient.Synapse):
             SynapseExternalFileLinkTool(syn=syn),
             SynapseBatchFolderCreationTool(syn=syn),
             SynapseBatchExternalFileLinkTool(syn=syn),
-            SynapsePythonCodeExecutorTool(syn=syn),
-            CodeInterpreterTool()
+            SynapsePythonCodeExecutorTool(syn=syn)
         ],
         llm=get_llm(),
         verbose=True,
@@ -133,8 +131,7 @@ class LinkExternalDataAgent(Agent):
                 SynapseExternalFileLinkTool(syn=syn),
                 SynapseBatchFolderCreationTool(syn=syn),
                 SynapseBatchExternalFileLinkTool(syn=syn),
-                SynapsePythonCodeExecutorTool(syn=syn),
-                CodeInterpreterTool()
+                SynapsePythonCodeExecutorTool(syn=syn)
             ],
             llm=get_llm(),
             verbose=True,

--- a/src/agents/ontology_expert.py
+++ b/src/agents/ontology_expert.py
@@ -1,0 +1,81 @@
+from crewai import Agent, Task
+from src.tools.zooma_tools import ZoomaTermMappingTool
+from src.utils.llm_utils import get_llm
+import subprocess
+
+def get_ontology_expert_agent():
+    return Agent(
+        role='Biomedical Ontology and Terminology Expert',
+        goal='Find the best-matching standardized ontology term for a given text, ensuring it is a sensible replacement in the given context.',
+        backstory=(
+            "You are an expert in biomedical ontologies and data modeling. Your mission is to provide high-quality, context-aware feedback on ontology term suggestions. "
+            "You must evaluate whether a suggested term is semantically appropriate for the given column. If not, you must say so."
+        ),
+        tools=[ZoomaTermMappingTool(llm=get_llm("ontology_expert"))],
+        verbose=True,
+        llm=get_llm("ontology_expert")
+    )
+
+class OntologyExpert(Agent):
+    def __init__(self, **kwargs):
+        super().__init__(
+            role='Biomedical Ontology and Terminology Expert',
+            goal='Find the best-matching standardized ontology term for a given text, ensuring it is a sensible replacement in the given context.',
+            backstory=(
+                "You are an expert in biomedical ontologies, including foundational ontologies like OBO, and "
+                "domain-specific ontologies like NCIT, EFO, and Mondo. You are adept at using mapping tools like ZOOMA "
+                "to find the best ontology term for a given text. You are also a critical thinker who can assess "
+                "whether a suggested term is a sensible replacement for a value in a specific column, based on "
+                "the context provided by other values in that column. You understand that not all mappings are "
+                "semantically valid, and your primary goal is to ensure accuracy and contextual appropriateness."
+            ),
+            tools=[ZoomaTermMappingTool(llm=get_llm("ontology_expert"))],
+            verbose=True,
+            allow_delegation=False,
+            max_iter=5,
+            instructions=(
+                "Your task is to find the best standardized ontology term for a given value in the context of a specific data column.\n"
+                "1.  **Analyze the context**: Carefully consider the column name and any existing values provided. This context is crucial for judging semantic appropriateness.\n"
+                "2.  **Find a term**: Use the 'ZOOMA Term Mapper' tool to find a candidate ontology term.\n"
+                "3.  **Evaluate the term**: Judge whether the found term is a sensible replacement. For example, a term for 'access level' is not a good replacement in a column for 'resource type'.\n"
+                "4.  **Handle failures**: If your first search fails or returns an inappropriate term, try a slightly different query (e.g., more general or specific). **If you still cannot find a good match after 2-3 attempts, you must stop.**\n"
+                "5.  **Final Answer**: Your final answer **MUST** be a single JSON object with three keys:\n"
+                "    -   `term`: The standardized term name (or `null` if no suitable term is found).\n"
+                "    -   `uri`: The full URI for the term (or `null`).\n"
+                "    -   `confidence_score`: A float from 0.0 to 1.0 representing your confidence. For example, `0.95`. **This MUST be a number, not a string.** A score of 0.0 means the term is not a sensible replacement.\n"
+                "Do not include any other text, thoughts, or explanations in your final answer."
+            ),
+            **kwargs
+        )
+
+    def file_github_issue(self, column_name, original_term, standard_term, uri):
+        """Formats and files a GitHub issue to propose a new term for the data model."""
+        issue_title = f"New Term Suggestion for '{column_name}': '{standard_term}'"
+        issue_body = (
+            f"A new term has been proposed for the **`{column_name}`** attribute in the data model.\\n\\n"
+            f"**Original Term:** `{original_term}`\\n"
+            f"**Suggested Term:** `{standard_term}`\\n"
+            f"**Suggested URI:** `{uri}`\\n\\n"
+            "This suggestion was approved during the data curation process. Please review and, if appropriate, add the new term to the data model."
+        )
+
+        try:
+            command = [
+                "gh", "issue", "create",
+                "--title", issue_title,
+                "--body", issue_body,
+                "--repo", self.repo_url
+            ]
+            result = subprocess.run(command, check=True, capture_output=True, text=True)
+            issue_url = result.stdout.strip()
+            print(f"\\n✅ Successfully created GitHub issue: {issue_url}")
+            return issue_url
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            print(f"\\n❌ Failed to create GitHub issue.")
+            print(f"Error: {e}")
+            return None
+
+    def _get_example_values(self, syn, view_id, column_name):
+        """Gets a few example values from a Synapse view column for context."""
+        # Implementation of _get_example_values method
+        pass 

--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -5,9 +5,11 @@ from .freetext_corrector import get_freetext_corrector_agent
 from .github_issue_filer import GitHubIssueFilerAgent
 from .ontology_expert import OntologyExpert
 from .link_external_data import get_link_external_data_agent
-from .sync_external_metadata import get_sync_external_metadata_agent
+from .pride_sync_agent import get_pride_sync_agent
+from .annotation_corrector import get_annotation_corrector_agent_from_config
+
 from .dataset_annotation_agent import get_dataset_annotation_agent
-from ..utils.llm_utils import get_llm
+from ..utils.llm_utils import get_llm, crew_kickoff_with_retry
 import os
 import synapseclient
 import json
@@ -42,8 +44,9 @@ class OrchestratorAgent:
             "github_issue_filer": GitHubIssueFilerAgent(),
             "ontology_expert": OntologyExpert(llm=get_llm('ontology_expert', self.llm_config)),
             "link_external_data": get_link_external_data_agent(syn=self.syn),
-            "sync_external_metadata": get_sync_external_metadata_agent(syn=self.syn),
-            "dataset_annotation_agent": get_dataset_annotation_agent(syn=self.syn)
+            "dataset_annotation_agent": get_dataset_annotation_agent(syn=self.syn),
+            "pride_sync_agent": get_pride_sync_agent(syn=self.syn),
+            "annotation_corrector": get_annotation_corrector_agent_from_config(syn=self.syn)
         }
 
     def _login_to_synapse(self):
@@ -85,9 +88,8 @@ class OrchestratorAgent:
             print("2. Standardize Uncontrolled Terms (e.g., investigator names)")
             print("3. Correct Free-Text Fields")
             print("4. Link External Dataset to Synapse (PRIDE, GEO, SRA, ENA, etc.)")
-            print("5. Sync External Metadata to Synapse Annotations")
-            print("6. Annotate Existing Synapse Dataset")
-            print("7. Exit")
+            print("5. Annotate Existing Synapse Dataset")
+            print("6. Exit")
 
             choice = input("Enter the number of your choice: ")
             if choice == '1':
@@ -99,13 +101,11 @@ class OrchestratorAgent:
             elif choice == '4':
                 self._run_link_external_data_manual()
             elif choice == '5':
-                self._run_sync_external_metadata_manual()
-            elif choice == '6':
                 self._run_dataset_annotation_manual()
-            elif choice == '7':
+            elif choice == '6':
                 break
             else:
-                print("Invalid choice. Please enter a number from 1 to 7.")
+                print("Invalid choice. Please enter a number from 1 to 6.")
 
     def _run_annotation_correction_manual(self):
         """
@@ -340,7 +340,7 @@ class OrchestratorAgent:
             )
 
             print("\nExecuting external data linking workflow...")
-            result = crew.kickoff()
+            result = crew_kickoff_with_retry(crew, context="external data linking workflow")
             
             print("\n" + "="*60)
             print("EXTERNAL DATA LINKING WORKFLOW COMPLETED")
@@ -351,76 +351,7 @@ class OrchestratorAgent:
             print(f"\nError during external data linking workflow: {e}")
             print("Please check your inputs and try again.")
 
-    def _run_sync_external_metadata_manual(self):
-        """
-        Manually runs the External Metadata to Synapse Annotations sync workflow.
-        """
-        print("\n--- External Metadata to Synapse Annotations Sync Workflow ---")
-        print("This workflow will apply external metadata (such as from PRIDE, GEO, etc.) as")
-        print("schema-compliant annotations to existing Synapse entities.")
-        
-        metadata_source = input("Enter the metadata source (e.g., 'PRIDE', 'GEO'): ").strip().upper()
-        
-        if metadata_source == 'PRIDE':
-            pride_id = input("Enter the PRIDE dataset ID (e.g., PXD001234): ").strip()
-            target_synapse_folder = input("Enter the Synapse folder ID containing the files to annotate: ").strip()
-            
-            if not pride_id or not target_synapse_folder:
-                print("PRIDE ID and Synapse folder ID are required. Exiting workflow.")
-                return
-            
-            print(f"\nApplying PRIDE metadata from {pride_id} to files in {target_synapse_folder}...")
-            
-            try:
-                from crewai import Task, Crew, Process
-                
-                task = Task(
-                    description=f"""
-                    Apply PRIDE dataset metadata as schema-compliant annotations to Synapse entities.
-                    
-                    Steps:
-                    1. Fetch metadata for PRIDE dataset {pride_id}
-                    2. Use PRIDE Annotation Mapper to generate schema-compliant annotations:
-                       - Map PRIDE metadata to valid schema attributes
-                       - Use data model URL: {self.data_model_path}
-                       - Ensure all annotation values are valid according to the schema
-                    3. Find all file entities in Synapse folder {target_synapse_folder} (including subfolders)
-                    4. Use apply_annotations to apply the mapped annotations to ALL files in ONE batch operation
-                    5. Provide a summary of annotations applied
-                    
-                    CRITICAL REQUIREMENTS:
-                    - ONLY use schema-valid annotation values
-                    - Do NOT hardcode annotation values - always validate against schema
-                    - Apply annotations in batch for efficiency
-                    - Provide detailed summary of what annotations were applied
-                    """,
-                    agent=self.agents["sync_external_metadata"],
-                    expected_output="A detailed summary of the external metadata sync operation including the annotations generated, files annotated, and any schema validation issues encountered."
-                )
-                
-                crew = Crew(
-                    agents=[self.agents["sync_external_metadata"]],
-                    tasks=[task],
-                    process=Process.sequential,
-                    verbose=True,
-                    memory=False
-                )
-                
-                print("\nExecuting external metadata sync workflow...")
-                result = crew.kickoff()
-                
-                print("\n" + "="*60)
-                print("EXTERNAL METADATA SYNC WORKFLOW COMPLETED")
-                print("="*60)
-                print(f"Result: {result}")
-                
-            except Exception as e:
-                print(f"\nError during external metadata sync workflow: {e}")
-                print("Please check your inputs and try again.")
-        
-        else:
-            print(f"Metadata source '{metadata_source}' is not yet supported.")
-            print("Currently supported sources: PRIDE")
+
 
     def _run_dataset_annotation_manual(self):
         """
@@ -440,6 +371,16 @@ class OrchestratorAgent:
         if not synapse_id.startswith('syn'):
             print("Warning: Synapse IDs typically start with 'syn'. Proceeding anyway...")
 
+        # Ask about ignoring existing annotations
+        print("\n--- Annotation Options ---")
+        ignore_existing = input("Do you want to IGNORE existing annotations on files? (y/N): ").strip().lower()
+        ignore_existing_annotations = ignore_existing in ['y', 'yes']
+        
+        if ignore_existing_annotations:
+            print("✅ Will ignore existing annotations (useful when current annotations are incorrect)")
+        else:
+            print("ℹ️  Will consider existing annotations as context")
+
         print(f"\nInitiating dataset analysis and annotation for {synapse_id}...")
         print("This will:")
         print("1. Analyze folder structure and classify files")
@@ -453,57 +394,33 @@ class OrchestratorAgent:
 
             task = Task(
                 description=f"""
-                Analyze and annotate Synapse dataset {synapse_id} with intelligent schema-based annotations.
+                Analyze and annotate the Synapse dataset {synapse_id} using the JSON-LD schema at {self.data_model_path}.
                 
-                Follow these steps in order:
+                IMPORTANT: {'IGNORE existing annotations on files - they may be incorrect and should not influence decisions.' if ignore_existing_annotations else 'Consider existing annotations as context, but verify their accuracy.'}
                 
-                1. ANALYZE FOLDER STRUCTURE:
-                   - Use Synapse Folder Analysis Tool to scan {synapse_id} recursively
-                   - Identify and classify all files (data vs metadata vs other)
-                   - Extract external identifiers from names, descriptions, and annotations
-                   - Get summary of file types, sizes, and existing annotations
+                Your approach should be:
+                1. Analyze the dataset structure to understand what files are present
+                   {'- Use ignore_existing_annotations=True when calling Synapse Folder Analysis Tool' if ignore_existing_annotations else '- Include existing annotations in analysis'}
+                2. Choose the best processing strategy based on complexity:
+                   - Simple datasets: process all files together
+                   - Complex datasets with many folders/identifiers: process incrementally folder by folder
+                3. For complex datasets with folders: Process ONE folder at a time (never batch):
+                   - Pick one folder (e.g., SRR21492342)
+                   - Extract biological identifier from that folder name
+                   - Use bioregistry tools to get ACTUAL metadata for that specific identifier
+                   - Try to get displayNames from schema, but proceed with defaults if tools fail
+                   - Build annotations using correct field names (e.g., 'readPair' not 'ReadPair')  
+                   - ACTUALLY apply annotations to that ONE folder using 'annotate_folder' tool
+                   - Move to the next folder and repeat until all folders are processed
+                4. CRITICAL: Never try to process multiple folders at once or create large batches
+                   ALWAYS use 'annotate_folder' tool to actually annotate files - don't just plan!
                 
-                2. ANALYZE METADATA FILES:
-                   - If metadata files are found, use Metadata File Analysis Tool to extract structured information
-                   - Parse up to 5 metadata files to gather additional context
-                   - Extract key-value pairs, tabular data, or structured information
-                
-                3. DETERMINE APPROPRIATE TEMPLATE:
-                   - Use Template Detection Tool to get all available templates from the schema
-                   - Use data model URL: {self.data_model_path}
-                   - Analyze file types, external identifiers, and metadata content
-                   - Based on the evidence, select the most appropriate metadata template
-                   - Consider file extensions, content types, external repository IDs, and metadata content
-                
-                4. GENERATE ANNOTATIONS:
-                   - Use Annotation Generation Tool with the chosen template
-                   - Use data model URL: {self.data_model_path}
-                   - Get controlled vocabulary options for each template attribute
-                   - Map available metadata to appropriate schema attributes
-                   - Generate consistent annotations for all DATA files (not metadata files)
-                   - Ensure required attributes are filled and controlled vocabularies are used
-                
-                5. APPLY ANNOTATIONS:
-                   - Use apply_annotations to apply generated annotations to all data files in batch
-                   - Focus only on DATA files, not metadata or auxiliary files
-                   - Use the file classification from step 1 to determine which files to annotate
-                
-                6. SAVE DOCUMENTATION:
-                   - Use Annotation CSV Save Tool to create a local CSV record
-                   - Save to './dataset_annotations_{{timestamp}}.csv'
-                   - Include all generated annotations for documentation and review
-                
-                CRITICAL REQUIREMENTS:
-                - Only annotate DATA files, not metadata or auxiliary files
-                - Use schema-compliant controlled vocabulary values when available
-                - Fill all required template attributes
-                - Apply consistent annotations across similar files
-                - Base decisions on actual file analysis, not assumptions
-                - Let the available templates and metadata guide the annotation process
-                - ALWAYS use data model URL: {self.data_model_path} for ALL JSON-LD operations
+                Focus only on data files and use exact displayName from the JSON-LD schema for all 
+                attribute names. Always fetch actual metadata rather than making assumptions. 
+                Process folder by folder to ensure accuracy and avoid system overload.
                 """,
                 agent=self.agents["dataset_annotation_agent"],
-                expected_output="A comprehensive summary of the dataset analysis and annotation process, including the number of files analyzed, template selected, annotations applied, and any issues encountered. Include the path to the saved CSV file with annotation details."
+                expected_output="A summary of the annotation process including the template used, number of files annotated, and any key annotations applied."
             )
             
             crew = Crew(
@@ -514,12 +431,21 @@ class OrchestratorAgent:
                 memory=False
             )
             
-            result = crew.kickoff()
+            result = crew_kickoff_with_retry(crew, context="dataset annotation workflow")
             print(f"\nDataset annotation workflow completed successfully!")
             print(f"Result: {result}")
             
+        except ValueError as e:
+            # Handle the specific error from crew_kickoff_with_retry
+            if "Invalid response from LLM call" in str(e):
+                print(f"\n❌ Dataset annotation workflow failed due to a persistent issue with the language model.")
+                print(f"   Please try again later. If the problem continues, check the model configuration or API status.")
+                print(f"   Details: {e}")
+            else:
+                # Re-raise other ValueErrors
+                raise
         except Exception as e:
-            print(f"Error running dataset annotation workflow: {e}")
+            print(f"An unexpected error occurred during the dataset annotation workflow: {e}")
             import traceback
             traceback.print_exc()
 
@@ -585,7 +511,7 @@ class OrchestratorAgent:
             memory=False
         )
         
-        result = crew.kickoff()
+        result = crew_kickoff_with_retry(crew, context="ontology expert consultation")
         
         try:
             # The result from crew.kickoff() is a CrewOutput object, we need the raw string from it

--- a/src/agents/pride_sync_agent.py
+++ b/src/agents/pride_sync_agent.py
@@ -1,0 +1,110 @@
+from crewai import Agent
+from src.utils.llm_utils import get_llm
+from src.tools.pride_tools import (
+    PrideDatasetMetadataTool, 
+    PrideDatasetFilesTool
+)
+from src.tools.synapse_tools import (
+    SynapseFileUploadTool, 
+    SynapseFolderCreationTool,
+    SynapsePythonCodeExecutorTool,
+    SynapseExternalFileLinkTool,
+    SynapseBatchFolderCreationTool,
+    SynapseBatchExternalFileLinkTool
+)
+import synapseclient
+
+
+def get_pride_sync_agent(syn: synapseclient.Synapse):
+    """
+    Creates a PRIDE Sync Agent equipped with tools to fetch data from PRIDE repository
+    and upload it to Synapse containers.
+    
+    Args:
+        syn: Authenticated Synapse client instance
+        
+    Returns:
+        Agent configured for PRIDE-to-Synapse data synchronization
+    """
+    return Agent(
+        role='PRIDE Data Synchronization Specialist',
+        goal=(
+            'Retrieve proteomics datasets from the PRIDE repository and create '
+            'external file links in target Synapse containers (projects or folders) '
+            'with proper organization and folder structure.'
+        ),
+        backstory=(
+            "You are an expert in proteomics data management and bioinformatics infrastructure. "
+            "You specialize in working with the PRIDE (PRoteomics IDEntifications Database) repository, "
+            "which is the world's largest data repository of mass spectrometry-based proteomics data. "
+            "Your expertise includes:\n"
+            "- Navigating the PRIDE Archive REST API to retrieve dataset metadata and files\n"
+            "- Understanding proteomics data formats and file organization\n"
+            "- Managing large-scale data transfers efficiently\n"
+            "- Organizing data in Synapse with proper folder structures and annotations\n"
+            "- Ensuring data integrity and traceability during transfers\n\n"
+            "You are meticulous about creating logical folder structures and ensuring "
+            "that file organization reflects the original PRIDE dataset structure. "
+            "You focus on efficient file linking without downloading large datasets, "
+            "preserving external URLs and file metadata for downstream processing."
+        ),
+        tools=[
+            PrideDatasetMetadataTool(),
+            PrideDatasetFilesTool(),
+            SynapseFileUploadTool(syn=syn),
+            SynapseFolderCreationTool(syn=syn),
+            SynapseExternalFileLinkTool(syn=syn),
+            SynapseBatchFolderCreationTool(syn=syn),
+            SynapseBatchExternalFileLinkTool(syn=syn),
+            SynapsePythonCodeExecutorTool(syn=syn)
+        ],
+        llm=get_llm("pride_sync_agent"),
+        verbose=True,
+        allow_delegation=False
+    )
+
+
+class PrideSyncAgent(Agent):
+    """
+    Alternative class-based implementation of the PRIDE Sync Agent.
+    Use get_pride_sync_agent() function for most use cases.
+    """
+    
+    def __init__(self, syn: synapseclient.Synapse):
+        self.syn = syn
+        super().__init__(
+            role='PRIDE Data Synchronization Specialist',
+            goal=(
+                'Retrieve proteomics datasets from the PRIDE repository and create '
+                'external file links in target Synapse containers (projects or folders) '
+                'with proper organization and folder structure.'
+            ),
+            backstory=(
+                "You are an expert in proteomics data management and bioinformatics infrastructure. "
+                "You specialize in working with the PRIDE (PRoteomics IDEntifications Database) repository, "
+                "which is the world's largest data repository of mass spectrometry-based proteomics data. "
+                "Your expertise includes:\n"
+                "- Navigating the PRIDE Archive REST API to retrieve dataset metadata and files\n"
+                "- Understanding proteomics data formats and file organization\n"
+                "- Managing large-scale data transfers efficiently\n"
+                "- Organizing data in Synapse with proper folder structures and annotations\n"
+                "- Ensuring data integrity and traceability during transfers\n\n"
+                "You are meticulous about creating logical folder structures and ensuring "
+                "that file organization reflects the original PRIDE dataset structure. "
+                "You focus on efficient file linking without downloading large datasets, "
+                "preserving external URLs and file metadata for downstream processing."
+            ),
+            tools=[
+                PrideDatasetMetadataTool(),
+                PrideDatasetFilesTool(),
+                SynapseFileUploadTool(syn=syn),
+                SynapseFolderCreationTool(syn=syn),
+                SynapseExternalFileLinkTool(syn=syn),
+                SynapseBatchFolderCreationTool(syn=syn),
+                SynapseBatchExternalFileLinkTool(syn=syn),
+                SynapsePythonCodeExecutorTool(syn=syn)
+            ],
+            llm=get_llm("pride_sync_agent"),
+            verbose=True,
+            allow_delegation=False
+        ) 

--- a/src/agents/synapse_agent.py
+++ b/src/agents/synapse_agent.py
@@ -1,0 +1,26 @@
+from crewai import Agent
+from src.tools.synapse_tools import UpdateViewTool, UpdateTableTool
+import synapseclient
+
+def get_synapse_agent(llm, syn: synapseclient.Synapse):
+    """
+    Creates a Synapse Agent equipped with tools to update Synapse views and tables.
+    """
+    return Agent(
+        role='Synapse Data Manager',
+        goal='Manage and update data stored in Synapse views and tables based on provided instructions and dataframes.',
+        backstory=(
+            "You are an expert agent specializing in interacting with the Synapse platform. "
+            "You are highly skilled at using the synapseclient library to perform data operations. "
+            "You are careful, precise, and always ensure that data updates are performed correctly "
+            "and efficiently. Your primary function is to take structured data in the form of pandas "
+            "DataFrames and apply updates to the corresponding Synapse entities."
+        ),
+        tools=[
+            UpdateViewTool(syn=syn),
+            UpdateTableTool(syn=syn)
+        ],
+        llm=llm,
+        verbose=True,
+        allow_delegation=False
+    ) 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import yaml
+import argparse
 
 # Add the project root to the Python path
 sys.path.append(str(Path(__file__).parent.parent))
@@ -20,8 +21,10 @@ def main():
         
         # Correctly parse the nested configuration
         ac_config = config.get('annotation_corrector', {})
+        fc_config = config.get('freetext_correction', {})
+        oe_config = config.get('ontology_expert', {})
         
-        orchestrator = OrchestratorAgent(ac_config=ac_config)
+        orchestrator = OrchestratorAgent(config=config)
         orchestrator.run()
     except (ValueError, FileNotFoundError) as e:
         print(f"\nError: {e}")

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -30,7 +30,9 @@ from .synapse_analysis_tools import (
     MetadataFileAnalysisTool,
     TemplateDetectionTool,
     SingleAttributeAnnotationTool,
-    AnnotationCSVBuilderTool,
+    CreateAnnotationCSVTool,
+    AddAnnotationColumnTool,
+    InspectCSVTool,
     AnnotationCSVSaveTool,
     ApplyAnnotationsFromCSVTool
 )
@@ -58,6 +60,8 @@ __all__ = [
     'TemplateDetectionTool',
     'AnnotationCSVSaveTool',
     'SingleAttributeAnnotationTool',
-    'AnnotationCSVBuilderTool',
+    'CreateAnnotationCSVTool',
+    'AddAnnotationColumnTool',
+    'InspectCSVTool',
     'ApplyAnnotationsFromCSVTool'
 ] 

--- a/src/tools/bioregistry_tools.py
+++ b/src/tools/bioregistry_tools.py
@@ -1,0 +1,546 @@
+"""
+Bioregistry Tools for Biological Identifier Resolution and Metadata Retrieval.
+
+These tools integrate with bioregistry.io and identifiers.org to resolve biological
+identifiers and fetch contextual metadata for dataset annotation.
+"""
+
+import requests
+import re
+from typing import Dict, List, Optional, Tuple, Any
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+import json
+from urllib.parse import urlparse, urljoin
+import time
+
+
+class BioregistryResolverInput(BaseModel):
+    """Input for resolving biological identifiers."""
+    identifier: str = Field(description="Biological identifier to resolve (e.g., 'sra:SRR21492342', 'SRR21492342', 'insdc.sra:SRR21492342')")
+    include_metadata: bool = Field(default=True, description="Whether to include additional metadata about the identifier")
+
+
+class BioregistryResolverTool(BaseTool):
+    name: str = "Bioregistry Identifier Resolver"
+    description: str = (
+        "Resolves biological identifiers using bioregistry.io and returns URLs, metadata, "
+        "and contextual information. Supports various formats like 'sra:SRR123', 'insdc.sra:SRR123', "
+        "or just 'SRR123' (will attempt to infer prefix)."
+    )
+    args_schema: type[BaseModel] = BioregistryResolverInput
+
+    def _run(self, identifier: str, include_metadata: bool = True) -> Dict[str, Any]:
+        """
+        Resolves a biological identifier using bioregistry.io.
+        
+        Args:
+            identifier: The identifier to resolve
+            include_metadata: Whether to include additional metadata
+            
+        Returns:
+            Dictionary with resolution results and metadata
+        """
+        try:
+            # Clean and parse the identifier
+            parsed_id = self._parse_identifier(identifier)
+            if not parsed_id:
+                return {"error": f"Could not parse identifier: {identifier}"}
+            
+            prefix, local_id = parsed_id
+            
+            # Try to resolve using bioregistry
+            result = self._resolve_with_bioregistry(prefix, local_id, include_metadata)
+            
+            # If bioregistry fails, try identifiers.org as fallback
+            if not result.get('resolved') and prefix and local_id:
+                result.update(self._resolve_with_identifiers_org(prefix, local_id))
+            
+            return result
+            
+        except Exception as e:
+            return {"error": f"Error resolving identifier: {str(e)}"}
+
+    def _parse_identifier(self, identifier: str) -> Optional[Tuple[str, str]]:
+        """Parse an identifier into prefix and local ID components."""
+        # Remove whitespace
+        identifier = identifier.strip()
+        
+        # Handle different formats
+        if ':' in identifier:
+            # Format: prefix:id or namespace.provider:id
+            parts = identifier.split(':', 1)
+            prefix = parts[0].lower()
+            local_id = parts[1]
+            
+            # Handle compound prefixes like 'insdc.sra'
+            if '.' in prefix:
+                # Try to map compound prefixes to standard ones
+                compound_mappings = {
+                    'insdc.sra': 'insdc.sra',
+                    'insdc.ena': 'ena',
+                    'ncbi.sra': 'insdc.sra',
+                    'ebi.ena': 'ena'
+                }
+                prefix = compound_mappings.get(prefix, prefix)
+            
+            return (prefix, local_id)
+        else:
+            # Try to infer prefix from the identifier pattern
+            inferred_prefix = self._infer_prefix_from_pattern(identifier)
+            if inferred_prefix:
+                return (inferred_prefix, identifier)
+        
+        return None
+
+    def _infer_prefix_from_pattern(self, identifier: str) -> Optional[str]:
+        """Infer the prefix based on identifier patterns."""
+        patterns = {
+            r'^SRR\d+$': 'insdc.sra',
+            r'^SRX\d+$': 'insdc.sra', 
+            r'^SRP\d+$': 'insdc.sra',
+            r'^SRS\d+$': 'insdc.sra',
+            r'^SAMN\d+$': 'biosample',
+            r'^SAME\d+$': 'biosample',
+            r'^SAMD\d+$': 'biosample',
+            r'^GSE\d+$': 'geo',
+            r'^GSM\d+$': 'geo',
+            r'^GPL\d+$': 'geo',
+            r'^PXD\d+$': 'pride',
+            r'^PRJ[A-Z]\w+$': 'bioproject',
+            r'^ERP\d+$': 'ena.project',
+            r'^ERR\d+$': 'ena.run',
+            r'^ERX\d+$': 'ena.experiment',
+            r'^ERS\d+$': 'ena.sample'
+        }
+        
+        for pattern, prefix in patterns.items():
+            if re.match(pattern, identifier, re.IGNORECASE):
+                return prefix
+        
+        return None
+
+    def _resolve_with_bioregistry(self, prefix: str, local_id: str, include_metadata: bool) -> Dict[str, Any]:
+        """Resolve using bioregistry.io API."""
+        result = {
+            'prefix': prefix,
+            'local_id': local_id,
+            'resolver': 'bioregistry',
+            'resolved': False
+        }
+        
+        try:
+            # Get prefix metadata from bioregistry
+            prefix_url = f"https://bioregistry.io/api/registry/{prefix}"
+            prefix_response = requests.get(prefix_url, timeout=10)
+            
+            if prefix_response.status_code == 200:
+                prefix_data = prefix_response.json()
+                result['prefix_metadata'] = prefix_data
+                result['resolved'] = True
+                
+                # Construct URLs
+                curie = f"{prefix}:{local_id}"
+                result['curie'] = curie
+                result['bioregistry_url'] = f"https://bioregistry.io/{curie}"
+                
+                # Get provider URLs if available
+                if 'uri_format' in prefix_data:
+                    try:
+                        provider_url = prefix_data['uri_format'].replace('$1', local_id)
+                        result['provider_url'] = provider_url
+                    except:
+                        pass
+                
+                if include_metadata:
+                    # Try to get additional metadata about the specific identifier
+                    ref_url = f"https://bioregistry.io/api/reference/{curie}"
+                    ref_response = requests.get(ref_url, timeout=10)
+                    if ref_response.status_code == 200:
+                        result['reference_metadata'] = ref_response.json()
+            
+        except requests.RequestException as e:
+            result['bioregistry_error'] = str(e)
+        
+        return result
+
+    def _resolve_with_identifiers_org(self, prefix: str, local_id: str) -> Dict[str, Any]:
+        """Fallback resolution using identifiers.org."""
+        result = {'identifiers_org_attempted': True}
+        
+        try:
+            # Try identifiers.org resolution API
+            curie = f"{prefix}:{local_id}"
+            resolver_url = f"https://resolver.api.identifiers.org/{curie}"
+            
+            response = requests.get(resolver_url, timeout=10)
+            if response.status_code == 200:
+                data = response.json()
+                result['identifiers_org_data'] = data
+                result['identifiers_org_url'] = f"https://identifiers.org/{curie}"
+                
+                # Extract provider URLs
+                if 'payload' in data and 'resolvedResources' in data['payload']:
+                    providers = data['payload']['resolvedResources']
+                    if providers:
+                        result['provider_urls'] = [r.get('compactIdentifierResolvedUrl') for r in providers if r.get('compactIdentifierResolvedUrl')]
+                        result['primary_provider_url'] = providers[0].get('compactIdentifierResolvedUrl')
+                
+                result['resolved'] = True
+                
+        except requests.RequestException as e:
+            result['identifiers_org_error'] = str(e)
+        
+        return result
+
+
+class BioregistryMetadataFetcherInput(BaseModel):
+    """Input for fetching metadata from resolved URLs."""
+    url: str = Field(description="URL to fetch metadata from")
+    parse_format: str = Field(default="auto", description="Format to parse (auto, json, xml, html)")
+
+
+class BioregistryMetadataFetcherTool(BaseTool):
+    name: str = "Bioregistry Metadata Fetcher"
+    description: str = (
+        "Fetches and parses metadata from URLs resolved by bioregistry. Can parse JSON, XML, "
+        "and HTML content to extract structured information about biological entities."
+    )
+    args_schema: type[BaseModel] = BioregistryMetadataFetcherInput
+
+    def _run(self, url: str, parse_format: str = "auto") -> Dict[str, Any]:
+        """
+        Fetches metadata from a URL and attempts to parse it.
+        
+        Args:
+            url: URL to fetch
+            parse_format: Format to parse (auto, json, xml, html)
+            
+        Returns:
+            Dictionary with fetched metadata
+        """
+        try:
+            # Set headers to appear as a browser
+            headers = {
+                'User-Agent': 'Mozilla/5.0 (compatible; BioregistryBot/1.0)',
+                'Accept': 'application/json, application/xml, text/html, text/plain, */*'
+            }
+            
+            response = requests.get(url, headers=headers, timeout=15)
+            response.raise_for_status()
+            
+            content_type = response.headers.get('content-type', '').lower()
+            content = response.text
+            
+            result = {
+                'url': url,
+                'status_code': response.status_code,
+                'content_type': content_type,
+                'content_length': len(content)
+            }
+            
+            # Parse based on content type or format
+            if parse_format == "auto":
+                if 'json' in content_type:
+                    parse_format = "json"
+                elif 'xml' in content_type:
+                    parse_format = "xml"
+                else:
+                    parse_format = "html"
+            
+            if parse_format == "json":
+                try:
+                    result['parsed_data'] = json.loads(content)
+                    result['format'] = 'json'
+                except json.JSONDecodeError:
+                    result['parse_error'] = 'Failed to parse as JSON'
+                    
+            elif parse_format == "xml":
+                result['format'] = 'xml'
+                result['xml_content'] = content[:5000]  # Truncate for safety
+                # Could add XML parsing here if needed
+                
+            elif parse_format == "html":
+                result['format'] = 'html'
+                # Extract useful information from HTML
+                result['extracted_metadata'] = self._extract_html_metadata(content)
+            
+            return result
+            
+        except requests.RequestException as e:
+            return {'error': f"Failed to fetch URL: {str(e)}", 'url': url}
+        except Exception as e:
+            return {'error': f"Error processing metadata: {str(e)}", 'url': url}
+
+    def _extract_html_metadata(self, html_content: str) -> Dict[str, Any]:
+        """Extract useful metadata from HTML content."""
+        metadata = {}
+        
+        # Extract title
+        title_match = re.search(r'<title[^>]*>(.*?)</title>', html_content, re.IGNORECASE | re.DOTALL)
+        if title_match:
+            metadata['title'] = title_match.group(1).strip()
+        
+        # Extract meta tags
+        meta_matches = re.findall(r'<meta\s+([^>]+)>', html_content, re.IGNORECASE)
+        meta_tags = {}
+        for meta in meta_matches:
+            # Parse attributes
+            attrs = {}
+            attr_matches = re.findall(r'(\w+)=["\']([^"\']*)["\']', meta)
+            for name, value in attr_matches:
+                attrs[name.lower()] = value
+            
+            if 'name' in attrs and 'content' in attrs:
+                meta_tags[attrs['name']] = attrs['content']
+            elif 'property' in attrs and 'content' in attrs:
+                meta_tags[attrs['property']] = attrs['content']
+        
+        if meta_tags:
+            metadata['meta_tags'] = meta_tags
+        
+        return metadata
+
+
+class IdentifierExtractorInput(BaseModel):
+    """Input for extracting identifiers from text."""
+    text: str = Field(description="Text to extract identifiers from")
+    identifier_types: List[str] = Field(default=[], description="Specific identifier types to look for (empty = all types)")
+
+
+class IdentifierExtractorTool(BaseTool):
+    name: str = "Biological Identifier Extractor"
+    description: str = (
+        "Extracts biological identifiers from text, file names, descriptions, etc. "
+        "Recognizes common patterns for SRA, BioSample, GEO, PRIDE, and other repositories."
+    )
+    args_schema: type[BaseModel] = IdentifierExtractorInput
+
+    def _run(self, text: str, identifier_types: List[str] = None) -> Dict[str, List[str]]:
+        """
+        Extracts biological identifiers from text.
+        
+        Args:
+            text: Text to search for identifiers
+            identifier_types: Specific types to look for (None = all types)
+            
+        Returns:
+            Dictionary mapping identifier types to lists of found identifiers
+        """
+        if identifier_types is None:
+            identifier_types = []
+        
+        # Define patterns for different identifier types (flexible boundaries for real-world file names)
+        patterns = {
+            'sra_run': r'(SRR\d+)',
+            'sra_experiment': r'(SRX\d+)', 
+            'sra_project': r'(SRP\d+)',
+            'sra_sample': r'(SRS\d+)',
+            'biosample': r'(SAM[NED]\d+)',
+            'bioproject': r'(PRJ[A-Z]\w+)',
+            'geo_series': r'(GSE\d+)',
+            'geo_sample': r'(GSM\d+)',
+            'geo_platform': r'(GPL\d+)',
+            'pride': r'(PXD\d+)',
+            'ena_project': r'(ERP\d+)',
+            'ena_run': r'(ERR\d+)',
+            'ena_experiment': r'(ERX\d+)',
+            'ena_sample': r'(ERS\d+)',
+            'doi': r'(?:doi:)?(10\.\d+/[^\s]+)',
+            'pmid': r'(?:PMID:?)(\d+)',
+            'pmcid': r'(PMC\d+)'
+        }
+        
+        # Filter patterns if specific types requested
+        if identifier_types:
+            patterns = {k: v for k, v in patterns.items() if k in identifier_types}
+        
+        # Extract identifiers
+        found_identifiers = {}
+        
+        for id_type, pattern in patterns.items():
+            matches = re.findall(pattern, text, re.IGNORECASE)
+            if matches:
+                # Remove duplicates while preserving order
+                unique_matches = []
+                seen = set()
+                for match in matches:
+                    match_upper = match.upper()
+                    if match_upper not in seen:
+                        seen.add(match_upper)
+                        unique_matches.append(match_upper)
+                
+                found_identifiers[id_type] = unique_matches
+        
+        # Add summary
+        total_found = sum(len(ids) for ids in found_identifiers.values())
+        
+        return {
+            'found_identifiers': found_identifiers,
+            'total_found': total_found,
+            'text_length': len(text),
+            'searched_patterns': list(patterns.keys())
+        }
+
+
+class RelatedIdentifierFinderInput(BaseModel):
+    """Input for finding related identifiers."""
+    identifier: str = Field(description="Source identifier to find related identifiers for")
+    relation_types: List[str] = Field(default=[], description="Types of relations to find (e.g., 'sample', 'project', 'experiment')")
+
+
+class RelatedIdentifierFinderTool(BaseTool):
+    name: str = "Related Identifier Finder"
+    description: str = (
+        "Finds related biological identifiers by querying NCBI APIs and other sources. "
+        "For example, finds BioSample (SAMN) identifiers related to SRA runs (SRR), "
+        "or finds all runs in a project."
+    )
+    args_schema: type[BaseModel] = RelatedIdentifierFinderInput
+
+    def _run(self, identifier: str, relation_types: List[str] = None) -> Dict[str, Any]:
+        """
+        Finds related identifiers using various APIs.
+        
+        Args:
+            identifier: Source identifier
+            relation_types: Types of relations to find
+            
+        Returns:
+            Dictionary with related identifiers and metadata
+        """
+        if relation_types is None:
+            relation_types = []
+        
+        try:
+            # Parse the identifier
+            parsed = self._parse_identifier(identifier)
+            if not parsed:
+                return {'error': f'Could not parse identifier: {identifier}'}
+            
+            id_type, id_value = parsed
+            
+            result = {
+                'source_identifier': identifier,
+                'source_type': id_type,
+                'related_identifiers': {},
+                'metadata': {}
+            }
+            
+            # Find related identifiers based on source type
+            if id_type == 'sra_run':
+                result.update(self._find_sra_related(id_value, relation_types))
+            elif id_type == 'biosample':
+                result.update(self._find_biosample_related(id_value, relation_types))
+            elif id_type == 'bioproject':
+                result.update(self._find_bioproject_related(id_value, relation_types))
+            
+            return result
+            
+        except Exception as e:
+            return {'error': f'Error finding related identifiers: {str(e)}'}
+
+    def _parse_identifier(self, identifier: str) -> Optional[Tuple[str, str]]:
+        """Parse identifier into type and value."""
+        identifier = identifier.strip().upper()
+        
+        if identifier.startswith('SRR'):
+            return ('sra_run', identifier)
+        elif identifier.startswith('SRX'):
+            return ('sra_experiment', identifier)
+        elif identifier.startswith('SRP'):
+            return ('sra_project', identifier)
+        elif identifier.startswith('SAMN'):
+            return ('biosample', identifier)
+        elif identifier.startswith('PRJ'):
+            return ('bioproject', identifier)
+        
+        return None
+
+    def _find_sra_related(self, srr_id: str, relation_types: List[str]) -> Dict[str, Any]:
+        """Find identifiers related to an SRA run."""
+        related = {}
+        metadata = {}
+        
+        try:
+            # Use NCBI E-utilities to get SRA metadata
+            base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+            
+            # Search for the SRA run
+            search_url = f"{base_url}esearch.fcgi"
+            search_params = {
+                'db': 'sra',
+                'term': srr_id,
+                'retmode': 'json'
+            }
+            
+            search_response = requests.get(search_url, params=search_params, timeout=10)
+            if search_response.status_code == 200:
+                search_data = search_response.json()
+                
+                if 'esearchresult' in search_data and search_data['esearchresult'].get('idlist'):
+                    uid = search_data['esearchresult']['idlist'][0]
+                    
+                    # Get detailed information
+                    summary_url = f"{base_url}esummary.fcgi"
+                    summary_params = {
+                        'db': 'sra',
+                        'id': uid,
+                        'retmode': 'json'
+                    }
+                    
+                    summary_response = requests.get(summary_url, params=summary_params, timeout=10)
+                    if summary_response.status_code == 200:
+                        summary_data = summary_response.json()
+                        
+                        if 'result' in summary_data and uid in summary_data['result']:
+                            run_info = summary_data['result'][uid]
+                            metadata['sra_metadata'] = run_info
+                            
+                            # Extract related identifiers from the metadata
+                            expxml = run_info.get('expxml', '')
+                            runs = run_info.get('runs', '')
+                            
+                            # Look for BioSample IDs
+                            biosample_matches = re.findall(r'(SAMN\d+)', expxml + runs)
+                            if biosample_matches:
+                                related['biosample'] = list(set(biosample_matches))
+                            
+                            # Look for BioProject IDs  
+                            bioproject_matches = re.findall(r'(PRJ[A-Z]\w+)', expxml + runs)
+                            if bioproject_matches:
+                                related['bioproject'] = list(set(bioproject_matches))
+                            
+                            # Look for study/project IDs
+                            study_matches = re.findall(r'(SRP\d+)', expxml + runs)
+                            if study_matches:
+                                related['sra_project'] = list(set(study_matches))
+                            
+                            # Look for experiment IDs
+                            exp_matches = re.findall(r'(SRX\d+)', expxml + runs)
+                            if exp_matches:
+                                related['sra_experiment'] = list(set(exp_matches))
+                
+        except requests.RequestException as e:
+            metadata['ncbi_error'] = str(e)
+        
+        return {'related_identifiers': related, 'metadata': metadata}
+
+    def _find_biosample_related(self, biosample_id: str, relation_types: List[str]) -> Dict[str, Any]:
+        """Find identifiers related to a BioSample."""
+        # This could be implemented to find SRA runs associated with a BioSample
+        return {'related_identifiers': {}, 'metadata': {'note': 'BioSample relations not yet implemented'}}
+
+    def _find_bioproject_related(self, bioproject_id: str, relation_types: List[str]) -> Dict[str, Any]:
+        """Find identifiers related to a BioProject."""
+        # This could be implemented to find all SRA/BioSample records in a project
+        return {'related_identifiers': {}, 'metadata': {'note': 'BioProject relations not yet implemented'}}
+
+
+# Export all tools
+__all__ = [
+    'BioregistryResolverTool',
+    'BioregistryMetadataFetcherTool', 
+    'IdentifierExtractorTool',
+    'RelatedIdentifierFinderTool'
+] 

--- a/src/tools/geo_tools.py
+++ b/src/tools/geo_tools.py
@@ -1,0 +1,326 @@
+import GEOparse
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing import Type, List, Dict, Optional
+import pandas as pd
+import tempfile
+import os
+import requests
+import re
+import xml.etree.ElementTree as ET
+
+
+class GeoMetadataFetcherInput(BaseModel):
+    """Input for fetching GEO metadata."""
+    gse_id: str = Field(description="The GEO Series accession ID (e.g., GSE123456)")
+
+
+class GeoMetadataFetcherTool(BaseTool):
+    name: str = "GEO Metadata Fetcher"
+    description: str = (
+        "Fetches and parses experiment and sample metadata from a GEO Accession ID (GSE). "
+        "Returns a dictionary containing experiment metadata and a pandas DataFrame of sample metadata."
+    )
+    args_schema: Type[BaseModel] = GeoMetadataFetcherInput
+
+    def _run(self, gse_id: str) -> dict:
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                gse = GEOparse.get_GEO(geo=gse_id, destdir=tmpdir, silent=True)
+                
+                experiment_metadata = gse.metadata
+                sample_metadata_df = pd.DataFrame()
+
+                # Combine metadata from all GSM samples into a single DataFrame
+                all_gsm_metadata = []
+                for gsm_name, gsm in gse.gsms.items():
+                    gsm_metadata = gsm.metadata
+                    gsm_metadata['gsm'] = gsm_name
+                    all_gsm_metadata.append(gsm_metadata)
+                
+                if all_gsm_metadata:
+                    sample_metadata_df = pd.DataFrame(all_gsm_metadata)
+
+                return {
+                    "experiment_metadata": experiment_metadata,
+                    "sample_metadata": sample_metadata_df
+                }
+
+        except Exception as e:
+            return {"error": f"An error occurred while fetching GEO data: {str(e)}"} 
+
+
+class GeoDatasetFilesInput(BaseModel):
+    """Input for fetching GEO dataset file listings."""
+    gse_id: str = Field(description="The GEO Series accession ID (e.g., GSE123456)")
+
+
+class GeoDatasetFilesTool(BaseTool):
+    name: str = "GEO Dataset Files Fetcher"
+    description: str = (
+        "Fetches the list of files available for a GEO dataset including supplementary files, "
+        "raw data links, and processed data files. Returns information about each file "
+        "including name, size, type, and download URLs."
+    )
+    args_schema: Type[BaseModel] = GeoDatasetFilesInput
+
+    def _run(self, gse_id: str) -> dict:
+        """
+        Fetches file information for a GEO dataset.
+        
+        Args:
+            gse_id: GEO Series ID (e.g., GSE123456)
+            
+        Returns:
+            Dictionary containing file information and summary
+        """
+        try:
+            files = []
+            
+            # Method 1: Get supplementary files from GEO FTP
+            supp_files = self._get_supplementary_files(gse_id)
+            files.extend(supp_files)
+            
+            # Method 2: Get sample data files 
+            sample_files = self._get_sample_files(gse_id)
+            files.extend(sample_files)
+            
+            # Categorize files
+            file_categories = self._categorize_geo_files(files)
+            
+            return {
+                "gse_id": gse_id,
+                "total_files": len(files),
+                "files": files,
+                "file_categories": file_categories,
+                "summary": f"Found {len(files)} files for GEO dataset {gse_id}"
+            }
+            
+        except Exception as e:
+            return {
+                "gse_id": gse_id,
+                "error": f"Failed to fetch GEO files: {str(e)}",
+                "files": []
+            }
+
+    def _get_supplementary_files(self, gse_id: str) -> List[Dict]:
+        """Get supplementary files from GEO FTP server."""
+        supp_files = []
+        
+        try:
+            # GEO FTP URL pattern for supplementary files
+            base_ftp = f"https://ftp.ncbi.nlm.nih.gov/geo/series/{gse_id[:-3]}nnn/{gse_id}/suppl/"
+            
+            # Try to get directory listing
+            try:
+                response = requests.get(base_ftp, timeout=10)
+                if response.status_code == 200:
+                    # Parse HTML directory listing for file links
+                    file_links = re.findall(r'href="([^"]+\.[a-zA-Z0-9]+)"', response.text)
+                    
+                    for file_link in file_links:
+                        if not file_link.startswith('?'): # Skip parent directory links
+                            file_url = base_ftp + file_link
+                            
+                            # Try to get file size
+                            file_size = self._get_file_size(file_url)
+                            
+                            supp_files.append({
+                                'file_name': file_link,
+                                'file_size': file_size,
+                                'file_category': 'SUPPLEMENTARY',
+                                'file_type': self._determine_file_type(file_link),
+                                'download_url': file_url,
+                                'ftp_download_url': file_url.replace('https://', 'ftp://'),
+                                'compression': file_link.endswith(('.gz', '.bz2', '.zip')),
+                                'public_url': file_url
+                            })
+            except requests.RequestException:
+                # If HTTP fails, we still continue - some datasets might not have supp files
+                pass
+                
+        except Exception:
+            # Continue even if supplementary file fetching fails
+            pass
+            
+        return supp_files
+
+    def _get_sample_files(self, gse_id: str) -> List[Dict]:
+        """Get sample-level data files using GEOparse."""
+        sample_files = []
+        
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                gse = GEOparse.get_GEO(geo=gse_id, destdir=tmpdir, silent=True)
+                
+                # Check for platform data files
+                for gpl_name, gpl in gse.gpls.items():
+                    if hasattr(gpl, 'table') and gpl.table is not None:
+                        # This is platform annotation data
+                        sample_files.append({
+                            'file_name': f"{gpl_name}_annotation.txt",
+                            'file_size': len(str(gpl.table)) if gpl.table is not None else 0,
+                            'file_category': 'PLATFORM',
+                            'file_type': 'ANNOTATION',
+                            'download_url': f"https://ftp.ncbi.nlm.nih.gov/geo/platforms/{gpl_name[:-3]}/{gpl_name}/annot/{gpl_name}.annot.gz",
+                            'ftp_download_url': f"ftp://ftp.ncbi.nlm.nih.gov/geo/platforms/{gpl_name[:-3]}/{gpl_name}/annot/{gpl_name}.annot.gz",
+                            'compression': True,
+                            'public_url': f"https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc={gpl_name}"
+                        })
+                
+                # Check for series matrix files
+                if hasattr(gse, 'table') and gse.table is not None:
+                    sample_files.append({
+                        'file_name': f"{gse_id}_series_matrix.txt",
+                        'file_size': len(str(gse.table)) if gse.table is not None else 0,
+                        'file_category': 'PROCESSED',
+                        'file_type': 'MATRIX',
+                        'download_url': f"https://ftp.ncbi.nlm.nih.gov/geo/series/{gse_id[:-3]}nnn/{gse_id}/matrix/{gse_id}_series_matrix.txt.gz",
+                        'ftp_download_url': f"ftp://ftp.ncbi.nlm.nih.gov/geo/series/{gse_id[:-3]}nnn/{gse_id}/matrix/{gse_id}_series_matrix.txt.gz",
+                        'compression': True,
+                        'public_url': f"https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc={gse_id}"
+                    })
+                    
+        except Exception:
+            # Continue even if sample file fetching fails
+            pass
+            
+        return sample_files
+
+    def _get_file_size(self, url: str) -> int:
+        """Get file size from HTTP headers."""
+        try:
+            response = requests.head(url, timeout=5)
+            if response.status_code == 200:
+                content_length = response.headers.get('content-length')
+                if content_length:
+                    return int(content_length)
+        except:
+            pass
+        return 0
+
+    def _determine_file_type(self, filename: str) -> str:
+        """Determine file type based on extension."""
+        filename_lower = filename.lower()
+        
+        if filename_lower.endswith(('.txt', '.tsv', '.csv')):
+            return 'TEXT'
+        elif filename_lower.endswith(('.xlsx', '.xls')):
+            return 'SPREADSHEET'
+        elif filename_lower.endswith(('.tar', '.tar.gz', '.zip', '.gz')):
+            return 'ARCHIVE'
+        elif filename_lower.endswith(('.pdf')):
+            return 'DOCUMENT'
+        elif filename_lower.endswith(('.cel', '.cdf')):
+            return 'MICROARRAY'
+        elif filename_lower.endswith(('.fastq', '.fq', '.sra')):
+            return 'SEQUENCING'
+        else:
+            return 'OTHER'
+
+    def _categorize_geo_files(self, files: List[Dict]) -> Dict:
+        """Categorize files by type."""
+        categories = {
+            'SUPPLEMENTARY': [],
+            'PROCESSED': [],
+            'PLATFORM': [],
+            'RAW': []
+        }
+        
+        for file_info in files:
+            category = file_info.get('file_category', 'OTHER')
+            if category in categories:
+                categories[category].append(file_info['file_name'])
+            else:
+                categories['RAW'].append(file_info['file_name'])
+                
+        return {k: len(v) for k, v in categories.items()}
+
+
+class SrrToGeoMetadataInput(BaseModel):
+    """Input for fetching GEO metadata from an SRR ID."""
+    srr_id: str = Field(description="The SRA Run accession ID (e.g., SRR123456)")
+
+
+class SrrToGeoMetadataTool(BaseTool):
+    name: str = "SRR to GEO Metadata Fetcher"
+    description: str = (
+        "Fetches GEO metadata for a given SRA Run (SRR) ID by finding the "
+        "corresponding GEO Sample (GSM) and retrieving its metadata."
+    )
+    args_schema: Type[BaseModel] = SrrToGeoMetadataInput
+
+    def _run(self, srr_id: str) -> dict:
+        try:
+            # Step 1: Use E-utilities to find the GSM for the SRR
+            gsm_id = self._find_gsm_for_srr(srr_id)
+            if not gsm_id:
+                return {"error": f"Could not find a corresponding GEO Sample (GSM) for SRR ID {srr_id}."}
+
+            # Step 2: Use GEOparse to fetch metadata for the GSM
+            with tempfile.TemporaryDirectory() as tmpdir:
+                gsm = GEOparse.get_GEO(geo=gsm_id, destdir=tmpdir, silent=True)
+                if not gsm:
+                    return {"error": f"Failed to fetch metadata for GSM ID {gsm_id}."}
+                
+                return {
+                    "gsm_id": gsm_id,
+                    "metadata": gsm.metadata
+                }
+
+        except Exception as e:
+            return {"error": f"An error occurred: {str(e)}"}
+
+    def _find_gsm_for_srr(self, srr_id: str) -> Optional[str]:
+        """Finds the GEO Sample ID (GSM) for a given SRA Run ID (SRR)."""
+        try:
+            # Use esearch to find the SRA record UID for the SRR ID
+            esearch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+            esearch_params = {
+                'db': 'sra',
+                'term': srr_id,
+                'retmode': 'json'
+            }
+            search_response = requests.get(esearch_url, params=esearch_params, timeout=30)
+            search_response.raise_for_status()
+            search_data = search_response.json()
+            
+            sra_uid = search_data.get('esearchresult', {}).get('idlist', [])
+            if not sra_uid:
+                return None
+
+            # Use efetch to get the SRA experiment XML
+            efetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+            efetch_params = {
+                'db': 'sra',
+                'id': sra_uid[0],
+                'retmode': 'xml'
+            }
+            fetch_response = requests.get(efetch_url, params=efetch_params, timeout=30)
+            fetch_response.raise_for_status()
+            
+            # Parse XML to find the GSM ID
+            root = ET.fromstring(fetch_response.content)
+            # The structure is EXPERIMENT_PACKAGE -> EXPERIMENT -> IDENTIFIERS -> EXTERNAL_ID with namespace="GEO"
+            gsm_element = root.find(".//EXPERIMENT/IDENTIFIERS/EXTERNAL_ID[@namespace='GEO']")
+            if gsm_element is not None:
+                return gsm_element.text
+
+            # Fallback: check other locations
+            # Check SAMPLE
+            gsm_element = root.find(".//SAMPLE/IDENTIFIERS/EXTERNAL_ID[@namespace='GEO']")
+            if gsm_element is not None:
+                return gsm_element.text
+            
+            # Check RUN
+            gsm_element = root.find(".//RUN/IDENTIFIERS/EXTERNAL_ID[@namespace='GEO']")
+            if gsm_element is not None:
+                return gsm_element.text
+
+            return None
+        except requests.RequestException as e:
+            return None
+        except ET.ParseError as e:
+            return None
+        except Exception as e:
+            return None 

--- a/src/tools/human_tools.py
+++ b/src/tools/human_tools.py
@@ -1,0 +1,33 @@
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+import sys
+
+class AskHumanForFeedbackInput(BaseModel):
+    """Input for asking a human for feedback."""
+    question: str = Field(description="The question to ask the human.")
+
+class AskHumanForFeedbackTool(BaseTool):
+    name: str = "Ask Human For Feedback Tool"
+    description: str = (
+        "Asks a human for feedback on a specific question. "
+        "Use this when you need a human to review your work or provide additional information."
+    )
+    args_schema: type[BaseModel] = AskHumanForFeedbackInput
+
+    def _run(self, question: str) -> str:
+        """
+        Asks a human for feedback.
+        """
+        try:
+            print("\n" + "="*50)
+            print("HUMAN REVIEW REQUESTED".center(50))
+            print("="*50)
+            print(f"\n{question}")
+            
+            # Use standard input() for a normal terminal experience
+            feedback = input("> ")
+            
+            return feedback.strip()
+        
+        except Exception as e:
+            return f"An error occurred while asking for feedback: {str(e)}" 

--- a/src/tools/jsonld_tools.py
+++ b/src/tools/jsonld_tools.py
@@ -1,27 +1,75 @@
 from crewai.tools import BaseTool
 import json
 import requests
-from typing import List, Union
+from typing import List, Union, Dict, Type
+from src.tools.jsonld_utils import _load_jsonld
+from pydantic import BaseModel, Field
 
-def _load_jsonld(source: str):
-    """Loads a JSON-LD file from a URL or a local path."""
-    if source.startswith('http://') or source.startswith('https://'):
-        try:
-            response = requests.get(source)
-            response.raise_for_status()  # Raise an exception for bad status codes
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            raise Exception(f"Error fetching data from URL '{source}': {e}")
-        except json.JSONDecodeError:
-            raise Exception(f"Error: The content at '{source}' is not a valid JSON file.")
-    else:
-        try:
-            with open(source, 'r') as f:
-                return json.load(f)
-        except FileNotFoundError:
-            raise Exception(f"Error: The file '{source}' was not found.")
-        except json.JSONDecodeError:
-            raise Exception(f"Error: The file '{source}' is not a valid JSON file.")
+def get_common_rnaseq_display_names():
+    """
+    Fallback function that provides common displayNames for RNA-seq annotations
+    when schema parsing fails. Uses correct camelCase field names.
+    """
+    return {
+        'Component': 'component',
+        'Filename': 'filename', 
+        'FileFormat': 'fileFormat',
+        'ResourceType': 'resourceType',
+        'DataType': 'dataType',
+        'DataSubtype': 'dataSubtype',
+        'Assay': 'assay',
+        'IndividualID': 'individualID',
+        'Species': 'species',
+        'Sex': 'sex',
+        'Age': 'age',
+        'AgeUnit': 'ageUnit',
+        'Diagnosis': 'diagnosis',
+        'Nf1Genotype': 'nf1Genotype',
+        'Nf2Genotype': 'nf2Genotype', 
+        'TumorType': 'tumorType',
+        'ModelSystemName': 'modelSystemName',
+        'Organ': 'organ',
+        'Comments': 'comments',
+        'ParentSpecimenID': 'parentSpecimenID',
+        'SpecimenID': 'specimenID',
+        'AliquotID': 'aliquotID',
+        'Platform': 'platform',
+        'NucleicAcidSource': 'nucleicAcidSource',
+        'SpecimenPreparationMethod': 'specimenPreparationMethod',
+        'SpecimenType': 'specimenType',
+        'RunType': 'runType',
+        'LibraryStrand': 'libraryStrand',
+        'LibraryPrep': 'libraryPrep',
+        'LibraryPreparationMethod': 'libraryPreparationMethod',
+        'ReadPair': 'readPair',
+        'ReadLength': 'readLength',
+        'ReadDepth': 'readDepth',
+        'TargetDepth': 'targetDepth',
+        'BatchID': 'batchID',
+        'GenePerturbed': 'genePerturbed',
+        'GenePerturbationType': 'genePerturbationType',
+        'GenePerturbationTechnology': 'genePerturbationTechnology',
+        'ExperimentalCondition': 'experimentalCondition',
+        'IsCellLine': 'isCellLine',
+        'IsXenograft': 'isXenograft'
+    }
+
+class CommonDisplayNamesInput(BaseModel):
+    """Input for getting common RNA-seq display names."""
+    pass
+
+class CommonRNASeqDisplayNamesTool(BaseTool):
+    name: str = "Get Common RNA-seq Display Names Tool"
+    description: str = (
+        "Returns common displayNames for RNA-seq annotations as a fallback when "
+        "schema parsing fails. Provides correct camelCase field names like 'readPair' "
+        "instead of 'ReadPair'. Use this when JSON-LD tools fail."
+    )
+    args_schema: Type[BaseModel] = CommonDisplayNamesInput
+
+    def _run(self) -> Dict[str, str]:
+        """Returns common RNA-seq displayNames mapping."""
+        return get_common_rnaseq_display_names()
 
 class JsonLdGetAttributeDisplayNameTool(BaseTool):
     name: str = "JSON-LD Get Attribute Display Name Tool"
@@ -57,31 +105,30 @@ class JsonLdGetValidValuesTool(BaseTool):
     name: str = "JSON-LD Get Valid Values Tool"
     description: str = "Parses a JSON-LD file from a URL or local path to get the list of valid 'displayNames' for a specific attribute, which is found by its 'label'."
 
-    def _run(self, source: str, attribute_name: str) -> Union[List[str], str]:
-        """
-        Parses the JSON-LD file to find the valid values for a given attribute.
-        """
+    def _run(self, attribute_name: str, data_model_url: str) -> list:
         try:
-            data_model = _load_jsonld(source)
+            jsonld_data = _load_jsonld(data_model_url)
+            return self._get_valid_values(jsonld_data, attribute_name)
         except Exception as e:
-            return str(e)
+            return [f"An error occurred: {str(e)}"]
 
-        if '@graph' not in data_model:
-            return "Error: JSON-LD file does not contain a '@graph' key."
+    def _get_valid_values(self, jsonld_data: dict, attribute_name: str) -> list:
+        if '@graph' not in jsonld_data:
+            return ["Error: JSON-LD file does not contain a '@graph' key."]
 
         # Find the parent attribute's ID using its label
         parent_id = None
-        for item in data_model['@graph']:
+        for item in jsonld_data['@graph']:
             if 'rdfs:label' in item and item['rdfs:label'].lower() == attribute_name.lower():
                 parent_id = item['@id']
                 break
 
         if not parent_id:
-            return f"Error: Attribute '{attribute_name}' not found in the data model."
+            return [f"Error: Attribute '{attribute_name}' not found in the data model."]
 
         # Find all subclasses of the parent attribute and get their displayNames
         valid_values = []
-        for item in data_model['@graph']:
+        for item in jsonld_data['@graph']:
             if 'rdfs:subClassOf' in item:
                 subclass_of_list = item['rdfs:subClassOf']
                 if not isinstance(subclass_of_list, list):
@@ -92,7 +139,7 @@ class JsonLdGetValidValuesTool(BaseTool):
                             valid_values.append(item['sms:displayName'])
 
         if not valid_values:
-            return f"No valid values (subclasses with displayNames) found for attribute '{attribute_name}'."
+            return [f"No valid values (subclasses with displayNames) found for attribute '{attribute_name}'."]
 
         return valid_values 
 
@@ -125,3 +172,79 @@ class JsonLdGetManifestsTool(BaseTool):
 
         except Exception as e:
             return f"Error: {e}" 
+
+class JsonLdAttributeDisplayNamesInput(BaseModel):
+    """Input for getting attribute display names from JSON-LD schema."""
+    template_name: str = Field(description="Name of the template/component (e.g., 'RNASeqTemplate', 'ScRNASeqTemplate')")
+    data_model_url: str = Field(description="URL or path to the JSON-LD data model")
+
+class JsonLdAttributeDisplayNamesTool(BaseTool):
+    name: str = "JSON-LD Get Attribute Display Names Tool"
+    description: str = (
+        "Gets the correct displayName for all attributes in a specific template from a JSON-LD data model. "
+        "This ensures you use the correct field names (e.g., 'readPair' not 'ReadPair') when creating annotations. "
+        "Returns a mapping of attribute labels to their displayNames."
+    )
+    args_schema: Type[BaseModel] = JsonLdAttributeDisplayNamesInput
+
+    def _run(self, template_name: str, data_model_url: str) -> Dict[str, str]:
+        """
+        Gets the displayName for all attributes in a template.
+        
+        Args:
+            template_name: Name of the template (e.g., 'RNASeqTemplate')
+            data_model_url: URL or path to the JSON-LD data model
+            
+        Returns:
+            Dictionary mapping attribute labels to their displayNames
+        """
+        try:
+            # Load the JSON-LD data
+            if data_model_url.startswith(('http://', 'https://')):
+                response = requests.get(data_model_url)
+                response.raise_for_status()
+                data = response.json()
+            else:
+                with open(data_model_url, 'r') as f:
+                    data = json.load(f)
+            
+            # Find the template
+            template_data = None
+            graph = data.get('@graph', [])
+            
+            for item in graph:
+                if (item.get('@id', '').endswith(template_name) or 
+                    item.get('rdfs:label') == template_name or
+                    item.get('sms:displayName') == template_name):
+                    template_data = item
+                    break
+            
+            if not template_data:
+                return {"error": f"Template '{template_name}' not found in the data model"}
+            
+            # Get all properties for this template
+            properties = template_data.get('sms:properties', [])
+            
+            display_names = {}
+            
+            for prop in properties:
+                # Handle both direct properties and references
+                if isinstance(prop, dict):
+                    prop_id = prop.get('@id', '')
+                    label = prop_id.split(':')[-1] if ':' in prop_id else prop_id
+                    display_name = prop.get('sms:displayName', label)
+                    display_names[label] = display_name
+                elif isinstance(prop, str):
+                    # This is a reference, find the actual property definition
+                    prop_id = prop
+                    for item in graph:
+                        if item.get('@id') == prop_id:
+                            label = prop_id.split(':')[-1] if ':' in prop_id else prop_id
+                            display_name = item.get('sms:displayName', label)
+                            display_names[label] = display_name
+                            break
+            
+            return display_names
+            
+        except Exception as e:
+            return {"error": f"Failed to parse JSON-LD data model: {str(e)}"} 

--- a/src/tools/jsonld_utils.py
+++ b/src/tools/jsonld_utils.py
@@ -1,0 +1,22 @@
+import json
+import requests
+
+def _load_jsonld(source: str) -> dict:
+    """Loads a JSON-LD file from a URL or a local path."""
+    if source.startswith('http://') or source.startswith('https://'):
+        try:
+            response = requests.get(source)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Error fetching data from URL '{source}': {e}")
+        except json.JSONDecodeError:
+            raise Exception(f"Error: The content at '{source}' is not a valid JSON file.")
+    else:
+        try:
+            with open(source, 'r') as f:
+                return json.load(f)
+        except FileNotFoundError:
+            raise Exception(f"Error: The local file '{source}' was not found.")
+        except json.JSONDecodeError:
+            raise Exception(f"Error: The local file '{source}' is not a valid JSON file.") 

--- a/src/tools/pride_tools.py
+++ b/src/tools/pride_tools.py
@@ -1,0 +1,615 @@
+import requests
+import json
+import pandas as pd
+from crewai.tools import BaseTool
+from typing import Optional, Type, Dict, Any
+from pydantic import BaseModel, Field
+import tempfile
+import os
+from urllib.parse import urljoin
+from .jsonld_tools import JsonLdGetValidValuesTool, JsonLdGetManifestsTool, _load_jsonld
+
+
+class PrideDatasetMetadataInput(BaseModel):
+    """Input for fetching PRIDE dataset metadata."""
+    pride_id: str = Field(description="The PRIDE dataset accession ID (e.g., PXD001234)")
+
+
+class PrideDatasetFilesInput(BaseModel):
+    """Input for fetching PRIDE dataset file listings."""
+    pride_id: str = Field(description="The PRIDE dataset accession ID (e.g., PXD001234)")
+
+
+class PrideDatasetMetadataTool(BaseTool):
+    name: str = "PRIDE Dataset Metadata Fetcher"
+    description: str = (
+        "Fetches metadata for a PRIDE dataset using the PRIDE Archive REST API. "
+        "Returns comprehensive dataset information including title, description, "
+        "species, instruments, publication details, and submission information."
+    )
+    args_schema: Type[BaseModel] = PrideDatasetMetadataInput
+
+    def _run(self, pride_id: str) -> dict:
+        """
+        Fetches metadata for a PRIDE dataset.
+        
+        Args:
+            pride_id: PRIDE accession ID (e.g., "PXD001234")
+            
+        Returns:
+            Dictionary containing dataset metadata or error information
+        """
+        base_url = "https://www.ebi.ac.uk/pride/ws/archive/v2/"
+        endpoint = f"projects/{pride_id}"
+        
+        try:
+            response = requests.get(urljoin(base_url, endpoint))
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            # Extract and structure key metadata
+            metadata = {
+                "accession": data.get("accession"),
+                "title": data.get("title"),
+                "description": data.get("projectDescription"),
+                "publication_date": data.get("publicationDate"),
+                "submission_date": data.get("submissionDate"),
+                "species": [species.get("name") for species in data.get("species", [])],
+                "instruments": [instr.get("name") for instr in data.get("instruments", [])],
+                "experiment_types": [exp.get("name") for exp in data.get("experimentTypes", [])],
+                "keywords": data.get("keywords", []),
+                "publications": [
+                    {
+                        "title": pub.get("title"),
+                        "authors": pub.get("authors"),
+                        "pubmed_id": pub.get("pubmedId"),
+                        "doi": pub.get("doi")
+                    } for pub in data.get("publications", [])
+                ],
+                "contacts": [
+                    {
+                        "name": contact.get("name"),
+                        "email": contact.get("email"),
+                        "affiliation": contact.get("affiliation")
+                    } for contact in data.get("contacts", [])
+                ],
+                "sample_processing_protocol": data.get("sampleProcessingProtocol"),
+                "data_processing_protocol": data.get("dataProcessingProtocol"),
+                "raw_data": data
+            }
+            
+            return metadata
+            
+        except requests.exceptions.RequestException as e:
+            return {"error": f"Failed to fetch PRIDE dataset metadata: {str(e)}"}
+        except json.JSONDecodeError as e:
+            return {"error": f"Failed to parse PRIDE API response: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Unexpected error while fetching PRIDE metadata: {str(e)}"}
+
+
+class PrideDatasetFilesTool(BaseTool):
+    name: str = "PRIDE Dataset Files Fetcher"
+    description: str = (
+        "Fetches the list of files available for a PRIDE dataset. "
+        "Returns information about each file including name, size, type, "
+        "and download URLs."
+    )
+    args_schema: Type[BaseModel] = PrideDatasetFilesInput
+
+    def _run(self, pride_id: str) -> dict:
+        """
+        Fetches file listings for a PRIDE dataset.
+        
+        Args:
+            pride_id: PRIDE accession ID (e.g., "PXD001234")
+            
+        Returns:
+            Dictionary containing file information or error details
+        """
+        base_url = "https://www.ebi.ac.uk/pride/ws/archive/v2/"
+        endpoint = f"projects/{pride_id}/files"
+        
+        try:            
+            response = requests.get(urljoin(base_url, endpoint))
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            files_info = []
+            # The response is a direct array of files
+            for file_data in data if isinstance(data, list) else []:
+                file_info = {
+                    "file_name": file_data.get("fileName"),
+                    "file_size": file_data.get("fileSizeBytes"),
+                    "file_category": file_data.get("fileCategory", {}).get("value") if file_data.get("fileCategory") else None,
+                    "file_type": file_data.get("fileCategory", {}).get("value") if file_data.get("fileCategory") else None,
+                    "compression": file_data.get("compress", False),
+                    "download_url": None,  # Will extract from publicFileLocations
+                    "ftp_download_url": None,  # Will extract from publicFileLocations
+                    "checksum": file_data.get("checksum"),
+                    "public_url": None  # Will extract from publicFileLocations
+                }
+                
+                # Extract download URLs from publicFileLocations
+                public_locations = file_data.get("publicFileLocations", [])
+                for location in public_locations:
+                    if location.get("name") == "FTP Protocol":
+                        file_info["ftp_download_url"] = location.get("value")
+                        if not file_info["download_url"]:  # Use FTP as primary download URL
+                            file_info["download_url"] = location.get("value")
+                    elif location.get("name") == "Aspera Protocol":
+                        # Could add aspera support later if needed
+                        pass
+                files_info.append(file_info)
+            
+            # Create summary statistics
+            summary = {
+                "total_files": len(files_info),
+                "total_size_bytes": sum(f.get("file_size", 0) for f in files_info if f.get("file_size")),
+                "file_types": list(set(f.get("file_type") for f in files_info if f.get("file_type"))),
+                "file_categories": list(set(f.get("file_category") for f in files_info if f.get("file_category")))
+            }
+            
+            return {
+                "pride_id": pride_id,
+                "summary": summary,
+                "files": files_info
+            }
+            
+        except requests.exceptions.RequestException as e:
+            return {"error": f"Failed to fetch PRIDE dataset files: {str(e)}"}
+        except json.JSONDecodeError as e:
+            return {"error": f"Failed to parse PRIDE API response: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Unexpected error while fetching PRIDE files: {str(e)}"}
+
+
+class PrideAnnotationMapperInput(BaseModel):
+    """Input for mapping PRIDE metadata to schema annotations."""
+    pride_metadata: dict = Field(description="PRIDE dataset metadata dictionary")
+    file_info: Optional[dict] = Field(default=None, description="PRIDE file information dictionary (optional)") 
+    data_model_url: str = Field(
+        default="https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld",
+        description="URL or path to the JSON-LD data model (defaults to NF schema if not provided)"
+    )
+
+
+class PrideAnnotationMapperTool(BaseTool):
+    name: str = "PRIDE Annotation Mapper"
+    description: str = (
+        "Intelligently maps PRIDE dataset and file metadata to appropriate schema annotations "
+        "based on the MassSpecAssayTemplate manifest. Uses JSON-LD schema analysis to determine "
+        "valid attributes and controlled vocabularies for intelligent mapping."
+    )
+    args_schema: Type[BaseModel] = PrideAnnotationMapperInput
+
+    def _run(self, pride_metadata: dict, file_info: Optional[dict] = None, data_model_url: str = "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld") -> dict:
+        """
+        Maps PRIDE metadata to schema annotations using intelligent schema-aware mapping.
+        
+        Args:
+            pride_metadata: PRIDE dataset metadata
+            file_info: PRIDE file information (optional, can be None)
+            data_model_url: URL or path to JSON-LD data model
+            
+        Returns:
+            Dictionary with mapping results, schema analysis, and mapping guidance
+        """
+        try:
+            # Step 1: Get the MassSpecAssayTemplate structure from the schema
+            manifests_tool = JsonLdGetManifestsTool()
+            manifests_result = manifests_tool._run(source=data_model_url)
+            
+            # Find MassSpecAssayTemplate - search more thoroughly
+            mass_spec_template = None
+            if isinstance(manifests_result, list):
+                for manifest in manifests_result:
+                    # Check if this manifest IS the MassSpecAssayTemplate
+                    if isinstance(manifest, dict):
+                        # Check various ways it might be identified
+                        manifest_id = manifest.get('@id', '')
+                        manifest_label = manifest.get('rdfs:label', '')
+                        manifest_name = manifest.get('name', '')
+                        
+                        if ('MassSpecAssayTemplate' in manifest_id or 
+                            'MassSpecAssayTemplate' in manifest_label or
+                            'MassSpecAssayTemplate' in manifest_name):
+                            mass_spec_template = manifest
+                            break
+                    
+                    # Also check string representation as fallback
+                    if 'MassSpecAssayTemplate' in str(manifest):
+                        mass_spec_template = manifest
+                        break
+            
+            # If manifests_result is a dict, it might contain the template directly
+            elif isinstance(manifests_result, dict):
+                if ('MassSpecAssayTemplate' in str(manifests_result) or
+                    manifests_result.get('@id', '').endswith('MassSpecAssayTemplate') or
+                    manifests_result.get('rdfs:label') == 'MassSpecAssayTemplate'):
+                    mass_spec_template = manifests_result
+            
+            if not mass_spec_template:
+                return {
+                    "error": "Could not find MassSpecAssayTemplate in the data model",
+                    "debug_info": f"Manifests result type: {type(manifests_result)}, length: {len(manifests_result) if isinstance(manifests_result, list) else 'N/A'}"
+                }
+            
+            # Step 2: Extract template attributes and their constraints
+            template_attributes = self._extract_template_attributes(mass_spec_template)
+            
+            # Step 3: Get valid values for attributes that might have controlled vocabularies
+            attribute_constraints = {}
+            valid_values_tool = JsonLdGetValidValuesTool()
+            
+            for attr in template_attributes[:15]:  # Limit to avoid too many API calls
+                try:
+                    valid_values = valid_values_tool._run(source=data_model_url, attribute_name=attr)
+                    if valid_values and isinstance(valid_values, list) and len(valid_values) > 0:
+                        # Check if the valid values contain URIs (controlled vocabulary)
+                        if any(isinstance(v, dict) and 'uri' in v for v in valid_values):
+                            attribute_constraints[attr] = valid_values
+                        elif len(valid_values) < 50:  # Reasonable number of enum values
+                            attribute_constraints[attr] = valid_values
+                except Exception:
+                    continue  # Skip if no valid values found
+            
+            # Step 4: Perform intelligent mapping
+            mapping_analysis = self._analyze_pride_data_for_mapping(
+                pride_metadata, file_info, template_attributes, attribute_constraints
+            )
+            
+            # Step 5: Apply the intelligent mapping
+            annotations = self._apply_intelligent_mapping(
+                pride_metadata, file_info, mapping_analysis
+            )
+            
+            return {
+                "success": True,
+                "annotations": annotations,
+                "total_annotations": len(annotations),
+                "template_attributes": template_attributes,
+                "attribute_constraints": {k: len(v) for k, v in attribute_constraints.items()},
+                "mapping_analysis": mapping_analysis,
+                "mapping_method": "Schema-aware intelligent mapping"
+            }
+            
+        except Exception as e:
+            return {"error": f"Failed to map PRIDE metadata to annotations: {str(e)}"}
+    
+    def _extract_template_attributes(self, template: dict) -> list:
+        """
+        Extract attribute names from the MassSpecAssayTemplate.
+        """
+        attributes = []
+        
+        try:
+            # Handle different possible template structures
+            if isinstance(template, dict):
+                # Look for properties in various possible keys
+                possible_props_keys = ['properties', 'sms:properties', 'attributes', '@graph']
+                
+                for key in possible_props_keys:
+                    if key in template:
+                        props = template[key]
+                        if isinstance(props, list):
+                            for prop in props:
+                                if isinstance(prop, dict):
+                                    # Extract attribute name from various possible formats
+                                    attr_name = (prop.get('rdfs:label') or 
+                                                prop.get('name') or 
+                                                prop.get('@id', '').split('/')[-1] or
+                                                prop.get('@id', '').split(':')[-1])
+                                    if attr_name and attr_name not in ['', 'MassSpecAssayTemplate']:
+                                        attributes.append(attr_name)
+                        elif isinstance(props, dict):
+                            attributes.extend([k for k in props.keys() if k not in ['@type', '@id']])
+                
+                # Also look for direct keys that might be attributes
+                direct_attrs = ['study', 'species', 'assay', 'platform', 'fileFormat', 
+                              'dataType', 'resourceId', 'doi', 'fileName', 'fileSize',
+                              'instrument', 'keywords', 'description', 'title']
+                attributes.extend(direct_attrs)
+            
+            # Remove duplicates and clean up
+            attributes = list(set([attr for attr in attributes if attr and isinstance(attr, str)]))
+            
+        except Exception as e:
+            print(f"Warning: Could not extract template attributes: {e}")
+            # Fallback to common proteomics attributes
+            attributes = ['study', 'species', 'assay', 'platform', 'fileFormat', 
+                         'dataType', 'resourceId', 'doi', 'fileName', 'fileSize']
+        
+        return attributes
+    
+    def _analyze_pride_data_for_mapping(self, pride_metadata: dict, file_info: Optional[dict], 
+                                       template_attributes: list, attribute_constraints: dict) -> dict:
+        """
+        Analyze PRIDE data and create intelligent mapping suggestions.
+        """
+        mapping_analysis = {
+            "direct_mappings": {},
+            "suggested_mappings": {},
+            "controlled_vocab_mappings": {},
+            "data_transformations": {},
+            "mapping_confidence": {}
+        }
+        
+        # Direct mappings (high confidence)
+        direct_map = {
+            'title': 'study',
+            'description': 'studyDescription', 
+            'accession': 'resourceId',
+            'file_name': 'fileName',
+            'file_size': 'fileSize'
+        }
+        
+        for pride_key, schema_attr in direct_map.items():
+            if schema_attr in template_attributes:
+                value_found = False
+                if pride_key in pride_metadata:
+                    value_found = True
+                elif file_info and pride_key in file_info:
+                    value_found = True
+                
+                if value_found:
+                    mapping_analysis["direct_mappings"][pride_key] = schema_attr
+                    mapping_analysis["mapping_confidence"][pride_key] = "high"
+        
+        # Species mapping with intelligent selection
+        if 'species' in template_attributes and pride_metadata.get('species'):
+            species_data = pride_metadata['species']
+            if attribute_constraints.get('species'):
+                # Try to match against controlled vocabulary
+                mapped_species = self._map_to_controlled_vocab(
+                    species_data, attribute_constraints['species'], 'species'
+                )
+                if mapped_species:
+                    mapping_analysis["controlled_vocab_mappings"]['species'] = mapped_species
+                    mapping_analysis["mapping_confidence"]['species'] = "medium"
+            else:
+                mapping_analysis["suggested_mappings"]['species'] = species_data
+                mapping_analysis["mapping_confidence"]['species'] = "high"
+        
+        # Assay/experiment type mapping
+        if 'assay' in template_attributes and pride_metadata.get('experiment_types'):
+            exp_types = pride_metadata['experiment_types']
+            if attribute_constraints.get('assay'):
+                mapped_assay = self._map_to_controlled_vocab(
+                    exp_types, attribute_constraints['assay'], 'assay'
+                )
+                if mapped_assay:
+                    mapping_analysis["controlled_vocab_mappings"]['assay'] = mapped_assay
+                    mapping_analysis["mapping_confidence"]['assay'] = "medium"
+            else:
+                mapping_analysis["suggested_mappings"]['assay'] = exp_types
+                mapping_analysis["mapping_confidence"]['assay'] = "high"
+        
+        # File format mapping based on PRIDE categories
+        if file_info and file_info.get('file_category'):
+            category = file_info['file_category']
+            format_mapping = {
+                'RAW': 'raw data',
+                'SEARCH': 'processed data', 
+                'OTHER': 'metadata'
+            }
+            
+            if 'fileFormat' in template_attributes:
+                suggested_format = format_mapping.get(category, category.lower())
+                if attribute_constraints.get('fileFormat'):
+                    mapped_format = self._map_to_controlled_vocab(
+                        [suggested_format], attribute_constraints['fileFormat'], 'fileFormat'
+                    )
+                    if mapped_format:
+                        mapping_analysis["controlled_vocab_mappings"]['fileFormat'] = mapped_format[0]
+                        mapping_analysis["mapping_confidence"]['fileFormat'] = "medium"
+                else:
+                    mapping_analysis["suggested_mappings"]['fileFormat'] = suggested_format
+                    mapping_analysis["mapping_confidence"]['fileFormat'] = "high"
+        
+        # Publication information
+        publications = pride_metadata.get('publications', [])
+        if publications:
+            pub = publications[0]
+            if 'doi' in template_attributes and pub.get('doi'):
+                mapping_analysis["direct_mappings"]['doi'] = 'doi'
+                mapping_analysis["mapping_confidence"]['doi'] = "high"
+            
+            if 'pubmedId' in template_attributes and pub.get('pubmed_id'):
+                mapping_analysis["data_transformations"]['pubmed_id'] = {
+                    'target_attr': 'pubmedId',
+                    'transformation': 'convert_to_string',
+                    'value': str(pub['pubmed_id'])
+                }
+                mapping_analysis["mapping_confidence"]['pubmed_id'] = "high"
+        
+        # Instrument mapping
+        if 'instrument' in template_attributes and pride_metadata.get('instruments'):
+            instruments = pride_metadata['instruments']
+            if attribute_constraints.get('instrument'):
+                mapped_instruments = self._map_to_controlled_vocab(
+                    instruments, attribute_constraints['instrument'], 'instrument'
+                )
+                if mapped_instruments:
+                    mapping_analysis["controlled_vocab_mappings"]['instrument'] = mapped_instruments
+                    mapping_analysis["mapping_confidence"]['instrument'] = "medium"
+            else:
+                mapping_analysis["suggested_mappings"]['instrument'] = instruments
+                mapping_analysis["mapping_confidence"]['instrument'] = "high"
+        
+        return mapping_analysis
+    
+    def _map_to_controlled_vocab(self, values: list, controlled_vocab: list, attr_name: str) -> list:
+        """
+        Intelligently map values to a controlled vocabulary.
+        """
+        if not values or not controlled_vocab:
+            return []
+        
+        mapped_values = []
+        
+        # Extract vocabulary terms
+        vocab_terms = []
+        for item in controlled_vocab:
+            if isinstance(item, dict):
+                term = item.get('term') or item.get('label') or item.get('name')
+                if term:
+                    vocab_terms.append((term, item))
+            elif isinstance(item, str):
+                vocab_terms.append((item, item))
+        
+        # Map each value
+        for value in values:
+            if isinstance(value, dict):
+                value_str = str(value.get('name', value))
+            else:
+                value_str = str(value)
+            
+            # Try exact match first
+            exact_match = None
+            for term, term_data in vocab_terms:
+                if value_str.lower() == term.lower():
+                    exact_match = term_data
+                    break
+            
+            if exact_match:
+                mapped_values.append(exact_match)
+                continue
+            
+            # Try partial matching
+            best_match = None
+            best_score = 0
+            for term, term_data in vocab_terms:
+                # Simple string similarity scoring
+                if value_str.lower() in term.lower() or term.lower() in value_str.lower():
+                    score = len(set(value_str.lower().split()) & set(term.lower().split()))
+                    if score > best_score:
+                        best_score = score
+                        best_match = term_data
+            
+            if best_match and best_score > 0:
+                mapped_values.append(best_match)
+        
+        return mapped_values
+    
+    def _apply_intelligent_mapping(self, pride_metadata: dict, file_info: Optional[dict], 
+                                 mapping_analysis: dict) -> dict:
+        """
+        Apply the intelligent mapping analysis to create final annotations.
+        """
+        annotations = {}
+        
+        # Apply direct mappings
+        for pride_key, schema_attr in mapping_analysis["direct_mappings"].items():
+            if pride_key in pride_metadata:
+                annotations[schema_attr] = pride_metadata[pride_key]
+            elif file_info and pride_key in file_info:
+                annotations[schema_attr] = file_info[pride_key]
+        
+        # Apply suggested mappings
+        for attr, value in mapping_analysis["suggested_mappings"].items():
+            annotations[attr] = value
+        
+        # Apply controlled vocabulary mappings
+        for attr, mapped_values in mapping_analysis["controlled_vocab_mappings"].items():
+            if isinstance(mapped_values, list):
+                if len(mapped_values) == 1:
+                    # Single value
+                    val = mapped_values[0]
+                    annotations[attr] = val.get('term') if isinstance(val, dict) else val
+                else:
+                    # Multiple values
+                    annotations[attr] = [
+                        (val.get('term') if isinstance(val, dict) else val) 
+                        for val in mapped_values
+                    ]
+            else:
+                # Single value
+                val = mapped_values
+                annotations[attr] = val.get('term') if isinstance(val, dict) else val
+        
+        # Apply data transformations
+        for pride_key, transform_info in mapping_analysis["data_transformations"].items():
+            target_attr = transform_info['target_attr']
+            annotations[target_attr] = transform_info['value']
+        
+        # ✅ FIXED: Use schema-aware mapping for dataType instead of hardcoding
+        if 'dataType' not in annotations:
+            # Try to map proteomics data to valid schema values
+            try:
+                from .jsonld_tools import JsonLdGetValidValuesTool
+                valid_values_tool = JsonLdGetValidValuesTool()
+                data_model_url = "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld"
+                
+                valid_data_types = valid_values_tool._run(source=data_model_url, attribute_name='dataType')
+                
+                # Look for mass spectrometry related values in the schema
+                proteomics_values = []
+                for val in valid_data_types or []:
+                    val_str = str(val).lower()
+                    if any(term in val_str for term in ['proteomic', 'mass spectrometry', 'ms']):
+                        proteomics_values.append(val)
+                
+                if proteomics_values:
+                    # Use the first matching value from the schema
+                    annotations['dataType'] = proteomics_values[0]
+                elif valid_data_types and 'proteomics' in [str(v).lower() for v in valid_data_types]:
+                    # Fallback to 'proteomics' if it exists
+                    annotations['dataType'] = 'proteomics'
+                    
+            except Exception:
+                # Only add dataType if we can validate it against schema
+                pass
+        
+        # ✅ FIXED: Use schema-aware mapping for platform instead of hardcoding
+        if 'platform' not in annotations:
+            try:
+                from .jsonld_tools import JsonLdGetValidValuesTool
+                valid_values_tool = JsonLdGetValidValuesTool()
+                data_model_url = "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld"
+                
+                valid_platforms = valid_values_tool._run(source=data_model_url, attribute_name='platform')
+                
+                # Look for PRIDE or mass spec platforms in the schema
+                if valid_platforms:
+                    pride_platforms = []
+                    for val in valid_platforms:
+                        val_str = str(val).lower()
+                        if any(term in val_str for term in ['pride', 'proteomics', 'mass spec']):
+                            pride_platforms.append(val)
+                    
+                    if pride_platforms:
+                        annotations['platform'] = pride_platforms[0]
+                        
+            except Exception:
+                # Only add platform if we can validate it against schema
+                pass
+        
+        # ✅ FIXED: Only add attributes that exist in the schema
+        schema_attrs = mapping_analysis.get("template_attributes", [])
+        
+        # Add resourceType only if it's in the schema
+        if 'resourceType' in schema_attrs and 'resourceType' not in annotations:
+            try:
+                from .jsonld_tools import JsonLdGetValidValuesTool
+                valid_values_tool = JsonLdGetValidValuesTool()
+                data_model_url = "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld"
+                
+                valid_resource_types = valid_values_tool._run(source=data_model_url, attribute_name='resourceType')
+                if valid_resource_types and 'proteomics' in [str(v).lower() for v in valid_resource_types]:
+                    annotations['resourceType'] = 'proteomics'
+            except Exception:
+                pass
+        
+        # ✅ FIXED: Only add dates if they're actually in the schema
+        if 'publicationDate' in schema_attrs and pride_metadata.get('publication_date'):
+            annotations['publicationDate'] = pride_metadata['publication_date']
+        # Note: removed submissionDate since user says it's not in their schema
+        
+        # Add keywords only if the attribute exists in schema
+        if 'keywords' in schema_attrs and pride_metadata.get('keywords'):
+            annotations['keywords'] = pride_metadata['keywords']
+        
+        return annotations 

--- a/src/tools/sra_tools.py
+++ b/src/tools/sra_tools.py
@@ -1,0 +1,473 @@
+import requests
+import xml.etree.ElementTree as ET
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing import Type, List, Dict, Optional
+import re
+import time
+
+
+class SraDatasetMetadataInput(BaseModel):
+    """Input for fetching SRA dataset metadata."""
+    srp_id: str = Field(description="The SRA Project accession ID (e.g., SRP399711)")
+
+
+class SraDatasetMetadataTool(BaseTool):
+    name: str = "SRA Dataset Metadata Fetcher"
+    description: str = (
+        "Fetches metadata for an SRA dataset using the NCBI E-utilities API. "
+        "Returns comprehensive dataset information including title, description, "
+        "experimental design, and sample information."
+    )
+    args_schema: Type[BaseModel] = SraDatasetMetadataInput
+
+    def _run(self, srp_id: str) -> dict:
+        """
+        Fetches metadata for an SRA dataset.
+        
+        Args:
+            srp_id: SRA Project ID (e.g., SRP399711)
+            
+        Returns:
+            Dictionary containing metadata
+        """
+        try:
+            # Step 1: Search for the SRP to get associated SRR IDs
+            search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+            search_params = {
+                'db': 'sra',
+                'term': f'{srp_id}[PRJA]',
+                'retmax': 100,
+                'retmode': 'xml'
+            }
+            
+            search_response = requests.get(search_url, params=search_params, timeout=30)
+            search_response.raise_for_status()
+            
+            # Parse search results
+            search_root = ET.fromstring(search_response.content)
+            id_list = search_root.find('.//IdList')
+            
+            if id_list is None or len(id_list) == 0:
+                return {
+                    "srp_id": srp_id,
+                    "error": f"No SRA records found for {srp_id}",
+                    "title": "Unknown",
+                    "description": "Dataset not found"
+                }
+            
+            # Get the first few IDs to fetch detailed metadata
+            sra_ids = [id_elem.text for id_elem in id_list.findall('Id')][:5]  # Limit for efficiency
+            
+            # Step 2: Fetch detailed metadata
+            fetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+            fetch_params = {
+                'db': 'sra',
+                'id': ','.join(sra_ids),
+                'retmode': 'xml'
+            }
+            
+            fetch_response = requests.get(fetch_url, params=fetch_params, timeout=30)
+            fetch_response.raise_for_status()
+            
+            # Parse metadata
+            metadata = self._parse_sra_metadata(fetch_response.content, srp_id)
+            return metadata
+            
+        except requests.RequestException as e:
+            return {
+                "srp_id": srp_id,
+                "error": f"Failed to fetch SRA metadata: {str(e)}",
+                "title": "Error",
+                "description": "Network error occurred"
+            }
+        except Exception as e:
+            return {
+                "srp_id": srp_id,
+                "error": f"Failed to parse SRA metadata: {str(e)}",
+                "title": "Error", 
+                "description": "Parsing error occurred"
+            }
+
+    def _parse_sra_metadata(self, xml_content: bytes, srp_id: str) -> dict:
+        """Parse SRA XML metadata."""
+        try:
+            root = ET.fromstring(xml_content)
+            
+            # Initialize metadata structure
+            metadata = {
+                "srp_id": srp_id,
+                "title": "Unknown",
+                "description": "No description available",
+                "organism": [],
+                "library_strategy": [],
+                "library_source": [],
+                "platform": [],
+                "submission_date": None,
+                "publication_date": None,
+                "total_samples": 0,
+                "total_experiments": 0,
+                "total_runs": 0
+            }
+            
+            # Extract information from SRA XML
+            experiments = root.findall('.//EXPERIMENT')
+            runs = root.findall('.//RUN')
+            samples = root.findall('.//SAMPLE')
+            
+            metadata["total_experiments"] = len(experiments)
+            metadata["total_runs"] = len(runs)
+            metadata["total_samples"] = len(samples)
+            
+            # Extract study information
+            studies = root.findall('.//STUDY')
+            if studies:
+                study = studies[0]
+                study_title = study.find('.//STUDY_TITLE')
+                if study_title is not None:
+                    metadata["title"] = study_title.text
+                
+                study_desc = study.find('.//STUDY_DESCRIPTION')
+                if study_desc is not None:
+                    metadata["description"] = study_desc.text
+            
+            # Extract sample/experiment details
+            organisms = set()
+            strategies = set()
+            sources = set()
+            platforms = set()
+            
+            for exp in experiments:
+                # Library strategy
+                lib_strategy = exp.find('.//LIBRARY_STRATEGY')
+                if lib_strategy is not None:
+                    strategies.add(lib_strategy.text)
+                
+                # Library source
+                lib_source = exp.find('.//LIBRARY_SOURCE')
+                if lib_source is not None:
+                    sources.add(lib_source.text)
+                
+                # Platform
+                platform = exp.find('.//PLATFORM')
+                if platform is not None:
+                    for child in platform:
+                        platforms.add(child.tag)
+            
+            for sample in samples:
+                # Organism
+                org_elem = sample.find('.//SCIENTIFIC_NAME')
+                if org_elem is not None:
+                    organisms.add(org_elem.text)
+            
+            metadata["organism"] = list(organisms)
+            metadata["library_strategy"] = list(strategies)
+            metadata["library_source"] = list(sources)
+            metadata["platform"] = list(platforms)
+            
+            return metadata
+            
+        except Exception as e:
+            return {
+                "srp_id": srp_id,
+                "error": f"Failed to parse XML: {str(e)}",
+                "title": "Error",
+                "description": "XML parsing failed"
+            }
+
+
+class SraDatasetFilesInput(BaseModel):
+    """Input for fetching SRA dataset file listings."""
+    srp_id: str = Field(description="The SRA Project accession ID (e.g., SRP399711)")
+    include_ena_fastq: bool = Field(default=True, description="Whether to also search for FASTQ files on ENA")
+
+
+class SraDatasetFilesTool(BaseTool):
+    name: str = "SRA Dataset Files Fetcher"
+    description: str = (
+        "Fetches the list of files available for an SRA dataset. Returns both SRA format files "
+        "and optionally searches for equivalent FASTQ files on ENA. Provides warnings about "
+        "file format limitations and download options."
+    )
+    args_schema: Type[BaseModel] = SraDatasetFilesInput
+
+    def _run(self, srp_id: str, include_ena_fastq: bool = True) -> dict:
+        """
+        Fetches file information for an SRA dataset.
+        
+        Args:
+            srp_id: SRA Project ID (e.g., SRP399711)
+            include_ena_fastq: Whether to search for FASTQ alternatives on ENA
+            
+        Returns:
+            Dictionary containing file information and warnings
+        """
+        try:
+            files = []
+            warnings = []
+            
+            # Step 1: Get SRA files
+            sra_files = self._get_sra_files(srp_id)
+            files.extend(sra_files)
+            
+            # Add warning about SRA format
+            if sra_files:
+                warnings.append(
+                    "WARNING: SRA provides files in .sra format only. These require SRA Toolkit "
+                    "to extract FASTQ files locally. For direct FASTQ access, consider ENA links below."
+                )
+            
+            # Step 2: Optionally search for ENA FASTQ files
+            ena_files = []
+            if include_ena_fastq:
+                ena_files = self._get_ena_fastq_files(srp_id)
+                files.extend(ena_files)
+                
+                if ena_files:
+                    warnings.append(
+                        "INFO: Found equivalent FASTQ files on ENA (European Nucleotide Archive). "
+                        "These provide direct access to FASTQ files without conversion."
+                    )
+                else:
+                    warnings.append(
+                        "INFO: No equivalent FASTQ files found on ENA. Only SRA format files are available."
+                    )
+            
+            # Categorize files
+            file_categories = self._categorize_sra_files(files)
+            
+            return {
+                "srp_id": srp_id,
+                "total_files": len(files),
+                "files": files,
+                "file_categories": file_categories,
+                "warnings": warnings,
+                "summary": f"Found {len(sra_files)} SRA files and {len(ena_files)} ENA FASTQ files for {srp_id}"
+            }
+            
+        except Exception as e:
+            return {
+                "srp_id": srp_id,
+                "error": f"Failed to fetch SRA files: {str(e)}",
+                "files": [],
+                "warnings": ["ERROR: Failed to fetch file information"]
+            }
+
+    def _get_sra_files(self, srp_id: str) -> List[Dict]:
+        """Get SRA format files."""
+        sra_files = []
+        
+        try:
+            # Try the ENA API first - it's more reliable for getting run accessions
+            ena_search_url = "https://www.ebi.ac.uk/ena/portal/api/search"
+            search_params = {
+                'result': 'read_run',
+                'query': f'secondary_study_accession="{srp_id}"',
+                'format': 'json',
+                'fields': 'run_accession,base_count,read_count',
+                'limit': 50
+            }
+            
+            response = requests.get(ena_search_url, params=search_params, timeout=30)
+            
+            if response.status_code == 200:
+                runs_data = response.json()
+                
+                for run in runs_data:
+                    run_acc = run.get('run_accession', '')
+                    
+                    if run_acc and run_acc.startswith('SRR'):
+                        # Get file size estimate from base count
+                        base_count = run.get('base_count', 0)
+                        read_count = run.get('read_count', 0)
+                        
+                        # Estimate SRA file size (typically 20-40% of base count)
+                        if base_count:
+                            try:
+                                bases = int(base_count)
+                                file_size = int(bases * 0.3)  # Conservative 30% estimate
+                                # Ensure minimum reasonable size
+                                if file_size < 1024 * 1024:  # Less than 1MB
+                                    file_size = 10 * 1024 * 1024  # 10MB minimum
+                            except (ValueError, TypeError):
+                                file_size = 100 * 1024 * 1024  # 100MB default
+                        else:
+                            file_size = 100 * 1024 * 1024  # 100MB default
+                        
+                        sra_files.append({
+                            'file_name': f"{run_acc}.sra",
+                            'file_size': file_size,
+                            'file_category': 'SRA',
+                            'file_type': 'SRA',
+                            'run_accession': run_acc,
+                            'download_url': f"https://sra-downloadb.be-md.ncbi.nlm.nih.gov/sos3/sra-pub-run-15/{run_acc}/{run_acc}.sra",
+                            'ftp_download_url': f"ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByRun/sra/SRR/{run_acc[:6]}/{run_acc}/{run_acc}.sra",
+                            'compression': False,
+                            'public_url': f"https://www.ncbi.nlm.nih.gov/sra/{run_acc}"
+                        })
+            
+            # If ENA didn't work, fall back to NCBI approach
+            if not sra_files:
+                # Search for runs in this project
+                search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+                search_params = {
+                    'db': 'sra',
+                    'term': f'{srp_id}[PRJA]',
+                    'retmax': 50,  # Limit to avoid too many files
+                    'retmode': 'xml'
+                }
+                
+                search_response = requests.get(search_url, params=search_params, timeout=30)
+                search_response.raise_for_status()
+                
+                # Parse search results
+                search_root = ET.fromstring(search_response.content)
+                id_list = search_root.find('.//IdList')
+                
+                if id_list is not None:
+                    sra_ids = [id_elem.text for id_elem in id_list.findall('Id')]
+                    
+                    # Fetch detailed info to get SRR accessions
+                    if sra_ids:
+                        fetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+                        fetch_params = {
+                            'db': 'sra',
+                            'id': ','.join(sra_ids[:20]),  # Limit for efficiency
+                            'retmode': 'xml'
+                        }
+                        
+                        fetch_response = requests.get(fetch_url, params=fetch_params, timeout=30)
+                        fetch_response.raise_for_status()
+                        
+                        # Parse runs
+                        root = ET.fromstring(fetch_response.content)
+                        runs = root.findall('.//RUN')
+                        
+                        for run in runs:
+                            run_acc = run.get('accession')
+                            if run_acc and run_acc.startswith('SRR'):
+                                # Get file size if available - try multiple possible locations
+                                file_size = 0
+                                size_elem = run.find('.//total_bases')
+                                if size_elem is not None:
+                                    try:
+                                        file_size = int(size_elem.text)
+                                    except (ValueError, TypeError):
+                                        pass
+                                
+                                # If no size found, try total_spots * avg_length
+                                if file_size == 0:
+                                    spots_elem = run.find('.//total_spots')
+                                    length_elem = run.find('.//avg_length')
+                                    if spots_elem is not None and length_elem is not None:
+                                        try:
+                                            spots = int(spots_elem.text)
+                                            length = int(length_elem.text)
+                                            file_size = spots * length  # Rough estimate
+                                        except (ValueError, TypeError):
+                                            pass
+                                
+                                # Default to 100MB if no size found
+                                if file_size == 0:
+                                    file_size = 100 * 1024 * 1024  # 100MB default
+                                
+                                sra_files.append({
+                                    'file_name': f"{run_acc}.sra",
+                                    'file_size': file_size,
+                                    'file_category': 'SRA',
+                                    'file_type': 'SRA',
+                                    'run_accession': run_acc,
+                                    'download_url': f"https://sra-downloadb.be-md.ncbi.nlm.nih.gov/sos3/sra-pub-run-15/{run_acc}/{run_acc}.sra",
+                                    'ftp_download_url': f"ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByRun/sra/SRR/{run_acc[:6]}/{run_acc}/{run_acc}.sra",
+                                    'compression': False,
+                                    'public_url': f"https://www.ncbi.nlm.nih.gov/sra/{run_acc}"
+                                })
+                            
+        except Exception as e:
+            # Continue even if SRA file fetching fails
+            pass
+            
+        return sra_files
+
+    def _get_ena_fastq_files(self, srp_id: str) -> List[Dict]:
+        """Get equivalent FASTQ files from ENA."""
+        ena_files = []
+        
+        try:
+            # Search ENA for the same project
+            # First try to find the project on ENA
+            ena_search_url = "https://www.ebi.ac.uk/ena/portal/api/search"
+            search_params = {
+                'result': 'read_run',
+                'query': f'secondary_study_accession="{srp_id}"',
+                'format': 'json',
+                'fields': 'run_accession,fastq_ftp,fastq_md5,fastq_bytes,base_count',
+                'limit': 50
+            }
+            
+            response = requests.get(ena_search_url, params=search_params, timeout=30)
+            
+            if response.status_code == 200:
+                runs_data = response.json()
+                
+                for run in runs_data:
+                    run_acc = run.get('run_accession', '')
+                    
+                    if run_acc:
+                        # Get FASTQ URLs
+                        fastq_ftp = run.get('fastq_ftp', '')
+                        fastq_md5 = run.get('fastq_md5', '')
+                        fastq_bytes = run.get('fastq_bytes', '')
+                        
+                        if fastq_ftp:
+                            # Parse multiple FASTQ files (paired-end)
+                            ftp_urls = fastq_ftp.split(';')
+                            md5_hashes = fastq_md5.split(';') if fastq_md5 else []
+                            file_sizes = fastq_bytes.split(';') if fastq_bytes else []
+                            
+                            for i, ftp_url in enumerate(ftp_urls):
+                                if ftp_url.strip():
+                                    file_name = ftp_url.split('/')[-1]
+                                    # Get actual file size from fastq_bytes
+                                    file_size = 0
+                                    if i < len(file_sizes) and file_sizes[i]:
+                                        try:
+                                            file_size = int(file_sizes[i])
+                                        except (ValueError, TypeError):
+                                            file_size = 0
+                                    
+                                    ena_files.append({
+                                        'file_name': file_name,
+                                        'file_size': file_size,
+                                        'file_category': 'FASTQ',
+                                        'file_type': 'FASTQ',
+                                        'run_accession': run_acc,
+                                        'download_url': f"https://{ftp_url}",
+                                        'ftp_download_url': f"ftp://{ftp_url}",
+                                        'compression': file_name.endswith('.gz'),
+                                        'md5_hash': md5_hashes[i] if i < len(md5_hashes) else None,
+                                        'public_url': f"https://www.ebi.ac.uk/ena/browser/view/{run_acc}"
+                                    })
+                            
+        except Exception as e:
+            # Continue even if ENA search fails
+            pass
+            
+        return ena_files
+
+    def _categorize_sra_files(self, files: List[Dict]) -> Dict:
+        """Categorize files by type."""
+        categories = {
+            'SRA': [],
+            'FASTQ': [],
+            'OTHER': []
+        }
+        
+        for file_info in files:
+            category = file_info.get('file_category', 'OTHER')
+            if category in categories:
+                categories[category].append(file_info['file_name'])
+            else:
+                categories['OTHER'].append(file_info['file_name'])
+                
+        return {k: len(v) for k, v in categories.items()} 

--- a/src/tools/synapse_analysis_tools.py
+++ b/src/tools/synapse_analysis_tools.py
@@ -10,6 +10,134 @@ import re
 import csv
 from urllib.parse import urljoin
 import synapseclient
+from src.tools.jsonld_utils import _load_jsonld
+from src.tools.jsonld_tools import JsonLdGetValidValuesTool
+
+
+def normalize_filename(filename: str) -> str:
+    """
+    Normalizes file names to handle common inconsistencies and ensure consistency.
+    
+    This function handles various file name issues that commonly occur:
+    - Compression extension inconsistencies (e.g., .fastq_gz -> .fastq.gz)
+    - Case inconsistencies in extensions
+    - Multiple dots in extensions
+    - Common typos and variations
+    
+    Args:
+        filename: Original file name
+        
+    Returns:
+        Normalized file name
+    """
+    if not filename:
+        return filename
+        
+    # Common compression extension patterns that need fixing
+    compression_patterns = [
+        # FASTQ files
+        (r'\.fastq_gz$', '.fastq.gz'),
+        (r'\.fq_gz$', '.fq.gz'),
+        (r'\.fastq\.gz\.gz$', '.fastq.gz'),  # Double compression
+        (r'\.fq\.gz\.gz$', '.fq.gz'),  # Double compression
+        
+        # Text files
+        (r'\.txt_gz$', '.txt.gz'),
+        (r'\.text_gz$', '.text.gz'),
+        (r'\.txt\.gz\.gz$', '.txt.gz'),  # Double compression
+        
+        # CSV/TSV files
+        (r'\.csv_gz$', '.csv.gz'),
+        (r'\.tsv_gz$', '.tsv.gz'),
+        (r'\.csv\.gz\.gz$', '.csv.gz'),  # Double compression
+        (r'\.tsv\.gz\.gz$', '.tsv.gz'),  # Double compression
+        
+        # JSON files
+        (r'\.json_gz$', '.json.gz'),
+        (r'\.json\.gz\.gz$', '.json.gz'),  # Double compression
+        
+        # XML files
+        (r'\.xml_gz$', '.xml.gz'),
+        (r'\.xml\.gz\.gz$', '.xml.gz'),  # Double compression
+        
+        # BAM/SAM files
+        (r'\.bam_gz$', '.bam.gz'),
+        (r'\.sam_gz$', '.sam.gz'),
+        (r'\.bam\.gz\.gz$', '.bam.gz'),  # Double compression
+        (r'\.sam\.gz\.gz$', '.sam.gz'),  # Double compression
+        
+        # VCF files
+        (r'\.vcf_gz$', '.vcf.gz'),
+        (r'\.vcf\.gz\.gz$', '.vcf.gz'),  # Double compression
+        
+        # Generic patterns for other file types
+        (r'\.([a-zA-Z0-9]+)_gz$', r'.\1.gz'),  # Any extension with _gz
+        (r'\.([a-zA-Z0-9]+)\.gz\.gz$', r'.\1.gz'),  # Double compression for any extension
+    ]
+    
+    normalized = filename
+    
+    # Apply compression pattern fixes
+    for pattern, replacement in compression_patterns:
+        normalized = re.sub(pattern, replacement, normalized, flags=re.IGNORECASE)
+    
+    # Fix common case inconsistencies in extensions
+    # Handle compound extensions like .fastq.gz, .txt.gz, etc.
+    if '.' in normalized:
+        # Split by dots to handle compound extensions
+        parts = normalized.split('.')
+        if len(parts) >= 2:
+            # For single extensions like .txt, .csv
+            if len(parts) == 2:
+                base_name = parts[0]
+                extension = parts[1].lower()
+            # For compound extensions like .fastq.gz, .txt.gz
+            else:
+                base_name = '.'.join(parts[:-2])
+                extension = '.'.join(parts[-2:]).lower()
+            
+            # Handle common extension variations
+            extension_mappings = {
+                'fastq': 'fastq',
+                'fq': 'fq', 
+                'txt': 'txt',
+                'text': 'text',
+                'csv': 'csv',
+                'tsv': 'tsv',
+                'json': 'json',
+                'xml': 'xml',
+                'bam': 'bam',
+                'sam': 'sam',
+                'vcf': 'vcf',
+                'gz': 'gz',
+                'zip': 'zip',
+                'tar': 'tar',
+                'bz2': 'bz2',
+                'xz': 'xz',
+                '7z': '7z',
+                'fastq.gz': 'fastq.gz',
+                'fq.gz': 'fq.gz',
+                'txt.gz': 'txt.gz',
+                'csv.gz': 'csv.gz',
+                'tsv.gz': 'tsv.gz',
+                'json.gz': 'json.gz',
+                'xml.gz': 'xml.gz',
+                'bam.gz': 'bam.gz',
+                'sam.gz': 'sam.gz',
+                'vcf.gz': 'vcf.gz',
+            }
+            
+            # Apply extension normalization
+            if extension in extension_mappings:
+                normalized = base_name + '.' + extension_mappings[extension]
+            else:
+                # If not in mappings, just normalize case
+                normalized = base_name + '.' + extension
+    
+    # Remove any trailing spaces or dots
+    normalized = normalized.rstrip('. ')
+    
+    return normalized
 
 # Handle relative imports for both development and production
 try:
@@ -26,6 +154,7 @@ except ImportError:
 class SynapseFolderAnalysisInput(BaseModel):
     """Input for analyzing a Synapse folder's contents."""
     synapse_id: str = Field(description="The Synapse ID of the folder or file to analyze")
+    ignore_existing_annotations: bool = Field(default=False, description="If True, ignore existing annotations on files (useful when current annotations are incorrect)")
 
 
 class SynapseFolderAnalysisTool(BaseTool):
@@ -43,12 +172,13 @@ class SynapseFolderAnalysisTool(BaseTool):
         super().__init__(**kwargs)
         self.syn = syn
 
-    def _run(self, synapse_id: str) -> dict:
+    def _run(self, synapse_id: str, ignore_existing_annotations: bool = False) -> dict:
         """
         Analyzes a Synapse folder and its contents.
         
         Args:
             synapse_id: Synapse ID of the folder/dataset to analyze
+            ignore_existing_annotations: If True, ignore existing annotations on files
             
         Returns:
             Dictionary containing structured analysis of folder contents
@@ -62,7 +192,8 @@ class SynapseFolderAnalysisTool(BaseTool):
             
             # Get all children recursively
             all_files = []
-            self._get_children_recursive(synapse_id, all_files)
+            all_folders = []
+            self._get_children_recursive(synapse_id, all_files, all_folders, ignore_existing_annotations)
             
             # Classify files
             data_files = []
@@ -79,30 +210,33 @@ class SynapseFolderAnalysisTool(BaseTool):
                     other_files.append(file_info)
             
             # Extract external identifiers
-            external_identifiers = self._extract_external_identifiers(all_files, entity)
-            
+            external_identifiers = self._extract_external_identifiers(all_files, entity, ignore_existing_annotations)
+
+            # Save data files to a temp file for other tools to use
+            data_files_path = None
+            if data_files:
+                with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json', prefix='data_files_') as f:
+                    json.dump(data_files, f)
+                    data_files_path = f.name
+
             return {
-                "synapse_id": synapse_id,
-                "entity_name": entity.name,
-                "entity_type": entity.__class__.__name__,
-                "total_files": len(all_files),
-                "data_files": data_files,
-                "metadata_files": metadata_files,
-                "other_files": other_files,
-                "external_identifiers": external_identifiers,
-                "summary": {
-                    "data_file_count": len(data_files),
-                    "metadata_file_count": len(metadata_files),
-                    "other_file_count": len(other_files),
-                    "identified_external_ids": list(external_identifiers.keys())
-                }
+                'synapse_id': synapse_id,
+                'entity_name': entity.name,
+                'entity_type': entity.__class__.__name__,
+                'total_files': len(all_files),
+                'folders': all_folders,
+                'data_files_path': data_files_path,
+                'data_files': data_files[:10],  # Return a sample for inspection
+                'metadata_files': metadata_files,
+                'other_files': other_files,
+                'external_identifiers': external_identifiers
             }
             
         except Exception as e:
             return {"error": f"Failed to analyze Synapse folder {synapse_id}: {str(e)}"}
 
-    def _get_children_recursive(self, parent_id: str, files_list: list):
-        """Recursively get all file children of a Synapse entity."""
+    def _get_children_recursive(self, parent_id: str, files_list: list, folders_list: list, ignore_existing_annotations: bool = False):
+        """Recursively get all file and folder children of a Synapse entity."""
         try:
             children = list(self.syn.getChildren(parent_id, includeTypes=["file", "folder"]))
             
@@ -114,23 +248,51 @@ class SynapseFolderAnalysisTool(BaseTool):
                     # Get file entity with annotations
                     try:
                         file_entity = self.syn.get(child_id, downloadFile=False)
+                        parent_folder = self.syn.get(file_entity.parentId, downloadFile=False)
+                        
+                        # Try multiple ways to get file size
+                        file_size = 0
+                        if hasattr(file_entity, 'contentSize') and file_entity.contentSize:
+                            file_size = file_entity.contentSize
+                        elif hasattr(file_entity, '_file_handle') and file_entity._file_handle:
+                            # Get file size from internal file handle
+                            file_size = file_entity._file_handle.get('contentSize', 0)
+                        elif hasattr(file_entity, 'dataFileHandleId'):
+                            # Get file handle to check size
+                            try:
+                                file_handle = self.syn.restGET(f'/fileHandle/{file_entity.dataFileHandleId}')
+                                file_size = file_handle.get('contentSize', 0)
+                            except Exception:
+                                file_size = 0  # Unknown size
+                        
+                        # Normalize file name to ensure consistency
+                        file_name = normalize_filename(file_entity.name)
+                        
                         file_info = {
                             'id': file_entity.id,
-                            'name': file_entity.name,
+                            'name': file_name,
                             'path': getattr(file_entity, 'path', ''),
                             'contentType': getattr(file_entity, 'contentType', ''),
-                            'contentSize': getattr(file_entity, 'contentSize', 0),
-                            'annotations': dict(file_entity.annotations) if hasattr(file_entity, 'annotations') else {},
+                            'contentSize': file_size,
+                            'annotations': {} if ignore_existing_annotations else (dict(file_entity.annotations) if hasattr(file_entity, 'annotations') else {}),
                             'description': getattr(file_entity, 'description', ''),
-                            'parent_id': parent_id
+                            'parent_id': file_entity.parentId,
+                            'parent_name': parent_folder.name
                         }
                         files_list.append(file_info)
                     except Exception as e:
                         print(f"Warning: Could not get file entity {child_id}: {e}")
                 
                 elif 'FolderEntity' in child_type or 'Folder' in child_type or child_type.endswith('.Folder'):
+                    # Get folder entity
+                    folder_entity = self.syn.get(child_id, downloadFile=False)
+                    folders_list.append({
+                        'id': folder_entity.id,
+                        'name': folder_entity.name,
+                        'parent_id': parent_id
+                    })
                     # Recurse into folder
-                    self._get_children_recursive(child_id, files_list)
+                    self._get_children_recursive(child_id, files_list, folders_list, ignore_existing_annotations)
                     
         except Exception as e:
             print(f"Warning: Could not get children of {parent_id}: {e}")
@@ -153,7 +315,7 @@ class SynapseFolderAnalysisTool(BaseTool):
         else:
             return "data"
 
-    def _extract_external_identifiers(self, files_list: list, main_entity) -> dict:
+    def _extract_external_identifiers(self, files_list: list, main_entity, ignore_existing_annotations: bool = False) -> dict:
         """Extract external identifiers from file names, descriptions, and annotations."""
         identifiers = {}
         
@@ -172,7 +334,7 @@ class SynapseFolderAnalysisTool(BaseTool):
         
         # Search in main entity
         search_text = f"{main_entity.name} {getattr(main_entity, 'description', '')}"
-        if hasattr(main_entity, 'annotations'):
+        if not ignore_existing_annotations and hasattr(main_entity, 'annotations'):
             for key, values in main_entity.annotations.items():
                 if isinstance(values, (list, tuple)):
                     search_text += " " + " ".join(str(v) for v in values)
@@ -182,11 +344,12 @@ class SynapseFolderAnalysisTool(BaseTool):
         # Search in all files
         for file_info in files_list:
             search_text += f" {file_info['name']} {file_info.get('description', '')}"
-            for key, values in file_info.get('annotations', {}).items():
-                if isinstance(values, (list, tuple)):
-                    search_text += " " + " ".join(str(v) for v in values)
-                else:
-                    search_text += " " + str(values)
+            if not ignore_existing_annotations:
+                for key, values in file_info.get('annotations', {}).items():
+                    if isinstance(values, (list, tuple)):
+                        search_text += " " + " ".join(str(v) for v in values)
+                    else:
+                        search_text += " " + str(values)
         
         # Find matches
         for id_type, pattern in patterns.items():
@@ -208,7 +371,7 @@ class MetadataFileAnalysisTool(BaseTool):
     description: str = (
         "Downloads and analyzes metadata files from Synapse to extract structured "
         "information that can be used for annotation. Supports common formats like "
-        "CSV, TSV, JSON, XML, and text files. Files larger than 10MB are automatically "
+        "CSV, TSV, JSON, XML, and text files. Files larger than 1MB are automatically "
         "skipped to avoid performance issues. Returns extracted metadata in a "
         "structured format."
     )
@@ -240,14 +403,29 @@ class MetadataFileAnalysisTool(BaseTool):
         file_ids = file_ids[:max_files]
         
         extracted_metadata = {}
-        max_file_size = 10 * 1024 * 1024  # 10MB in bytes
+        max_file_size = 1 * 1024 * 1024  # 1MB in bytes
         
         for file_id in file_ids:
             try:
                 # First get file entity without downloading to check size
                 file_entity_info = self.syn.get(file_id, downloadFile=False)
                 file_name = file_entity_info.name
-                file_size = getattr(file_entity_info, 'contentSize', 0)
+                
+                # Try multiple ways to get file size
+                file_size = 0
+                if hasattr(file_entity_info, 'contentSize') and file_entity_info.contentSize:
+                    file_size = file_entity_info.contentSize
+                elif hasattr(file_entity_info, '_file_handle') and file_entity_info._file_handle:
+                    # Get file size from internal file handle
+                    file_size = file_entity_info._file_handle.get('contentSize', 0)
+                elif hasattr(file_entity_info, 'dataFileHandleId'):
+                    # Get file handle to check size
+                    try:
+                        file_handle = self.syn.restGET(f'/fileHandle/{file_entity_info.dataFileHandleId}')
+                        file_size = file_handle.get('contentSize', 0)
+                    except Exception:
+                        # If we can't get the file handle, assume it might be large and skip
+                        file_size = max_file_size + 1
                 
                 # Check file size limit
                 if file_size > max_file_size:
@@ -255,7 +433,7 @@ class MetadataFileAnalysisTool(BaseTool):
                         'file_name': file_name,
                         'file_id': file_id,
                         'skipped': True,
-                        'reason': f'File too large ({file_size / (1024*1024):.1f}MB > 10MB limit)',
+                        'reason': f'File too large ({file_size / (1024*1024):.1f}MB > 1MB limit)',
                         'file_size_mb': file_size / (1024*1024)
                     }
                     continue
@@ -534,27 +712,29 @@ class TemplateDetectionTool(BaseTool):
 
     def _extract_template_attributes(self, jsonld_data: dict, template: dict) -> list:
         """Extract attributes defined for a template."""
-        template_id = template.get('@id', '')
-        
         attributes = []
+        template_node = template
+
+        if not template_node:
+            return []
+
+        # Get attribute IDs from sms:requiresDependency
+        required_dependencies = template_node.get('sms:requiresDependency', [])
+        if not isinstance(required_dependencies, list):
+            required_dependencies = [required_dependencies]
         
-        # Find all properties that have this template as domain or are required by it
-        for item in jsonld_data.get('@graph', []):
-            if 'sms:domainIncludes' in item:
-                domain_includes = item['sms:domainIncludes']
-                if not isinstance(domain_includes, list):
-                    domain_includes = [domain_includes]
-                
-                for domain in domain_includes:
-                    domain_id = domain.get('@id') if isinstance(domain, dict) else domain
-                    if domain_id == template_id:
-                        attr_info = {
-                            'id': item.get('@id', ''),
-                            'label': item.get('rdfs:label', ''),
-                            'description': item.get('rdfs:comment', ''),
-                            'required': item.get('sms:required', False)
-                        }
-                        attributes.append(attr_info)
+        attribute_ids = [dep.get('@id') for dep in required_dependencies if isinstance(dep, dict) and '@id' in dep]
+
+        # Look up each attribute's details
+        for attr_id in attribute_ids:
+            for item in jsonld_data.get('@graph', []):
+                if item.get('@id') == attr_id:
+                    attributes.append({
+                        'id': attr_id,
+                        'label': item.get('sms:displayName', item.get('rdfs:label', '')),
+                        'description': item.get('rdfs:comment', '')
+                    })
+                    break
         
         return attributes
 
@@ -808,6 +988,265 @@ class AnnotationCSVBuilderTool(BaseTool):
             return f"Failed to build/update CSV: {str(e)}"
 
 
+class CreateAnnotationCSVInput(BaseModel):
+    """Input for creating initial annotation CSV with file information."""
+    csv_path: str = Field(description="Path where to save the new CSV file (e.g., './annotations.csv')")
+    files_info: List[dict] = Field(description="List of file info dicts, each containing 'file_name' and 'synapse_id'")
+
+
+class CreateAnnotationCSVTool(BaseTool):
+    name: str = "Create Annotation CSV Tool"
+    description: str = (
+        "Creates a new annotation CSV file with file names and Synapse IDs. "
+        "This is the first step before adding annotation attributes. "
+        "MUCH SIMPLER to use than the complex CSV Builder Tool!"
+    )
+    args_schema: Type[BaseModel] = CreateAnnotationCSVInput
+
+    def _run(self, csv_path: str, files_info: List[dict]) -> str:
+        """
+        Creates a new annotation CSV with file information.
+        
+        Args:
+            csv_path: Path where to save the CSV
+            files_info: List of dicts with 'file_name' and 'synapse_id' keys
+            
+        Returns:
+            Status message
+        """
+        try:
+            if not files_info:
+                return "Error: No file information provided. Need at least one file with 'file_name' and 'synapse_id'."
+            
+            if os.path.exists(csv_path):
+                return f"Error: CSV file already exists at {csv_path}. Use 'Add Annotation Column Tool' to update it."
+            
+            # Validate required fields
+            for i, file_info in enumerate(files_info):
+                if 'file_name' not in file_info:
+                    return f"Error: File {i+1} missing 'file_name' field. Each file must have 'file_name' and 'synapse_id'."
+                if 'synapse_id' not in file_info:
+                    return f"Error: File {i+1} ('{file_info.get('file_name', 'unknown')}') missing 'synapse_id' field."
+            
+            # Create CSV data
+            csv_data = []
+            for file_info in files_info:
+                row = {
+                    'file_name': file_info['file_name'],
+                    'synapse_id': file_info['synapse_id']
+                }
+                csv_data.append(row)
+            
+            # Write CSV
+            with open(csv_path, 'w', newline='', encoding='utf-8') as csvfile:
+                fieldnames = ['file_name', 'synapse_id']
+                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(csv_data)
+            
+            return f"✅ Successfully created annotation CSV with {len(csv_data)} files at {csv_path}"
+            
+        except Exception as e:
+            return f"❌ Failed to create annotation CSV: {str(e)}"
+
+
+class AddAnnotationColumnInput(BaseModel):
+    """Input for adding an annotation column to existing CSV."""
+    csv_path: str = Field(description="Path to existing annotation CSV file")
+    attribute_name: str = Field(description="Name of the annotation attribute to add as a column")
+    attribute_values: dict = Field(description="Dictionary mapping file_name to attribute value")
+
+
+class AddAnnotationColumnTool(BaseTool):
+    name: str = "Add Annotation Column Tool"
+    description: str = (
+        "Adds a new annotation attribute column to an existing annotation CSV file. "
+        "The CSV must already exist (created with 'Create Annotation CSV Tool'). "
+        "SIMPLE to use - just provide the attribute name and values for each file!"
+    )
+    args_schema: Type[BaseModel] = AddAnnotationColumnInput
+
+    def _run(self, csv_path: str, attribute_name: str, attribute_values: dict) -> str:
+        """
+        Adds an annotation column to existing CSV.
+        
+        Args:
+            csv_path: Path to existing CSV file
+            attribute_name: Name of the attribute column to add
+            attribute_values: Dict mapping file_name to attribute value
+            
+        Returns:
+            Status message
+        """
+        try:
+            if not os.path.exists(csv_path):
+                return f"Error: CSV file not found at {csv_path}. Create it first with 'Create Annotation CSV Tool'."
+            
+            if not attribute_name or not attribute_name.strip():
+                return "Error: attribute_name cannot be empty. Provide a valid attribute name."
+            
+            if not attribute_values:
+                return "Error: attribute_values cannot be empty. Provide at least one file_name -> value mapping."
+            
+            # Read existing CSV
+            existing_data = []
+            existing_fieldnames = []
+            
+            with open(csv_path, 'r', encoding='utf-8') as csvfile:
+                reader = csv.DictReader(csvfile)
+                existing_fieldnames = list(reader.fieldnames or [])
+                existing_data = list(reader)
+            
+            if not existing_data:
+                return f"Error: CSV file at {csv_path} is empty. Create a valid CSV first."
+            
+            # Check if attribute already exists
+            if attribute_name in existing_fieldnames:
+                return f"Warning: Attribute '{attribute_name}' already exists. Updating existing values."
+            
+            # Add new attribute to fieldnames
+            if attribute_name not in existing_fieldnames:
+                existing_fieldnames.append(attribute_name)
+            
+            # Update data with new attribute values
+            files_updated = 0
+            files_found = set()
+            
+            for row in existing_data:
+                file_name = row.get('file_name', '')
+                files_found.add(file_name)
+                
+                if file_name in attribute_values:
+                    row[attribute_name] = attribute_values[file_name]
+                    files_updated += 1
+                else:
+                    # Set empty value for files not in the mapping
+                    row[attribute_name] = ''
+            
+            # Check for attribute_values that don't match any files in CSV
+            missing_files = set(attribute_values.keys()) - files_found
+            if missing_files:
+                missing_list = ', '.join(list(missing_files)[:5])  # Show first 5
+                # Show some actual file names from CSV for comparison
+                sample_files = list(files_found)[:5]
+                sample_list = ', '.join(sample_files)
+                
+                # Try to suggest normalized versions of missing files
+                suggestions = []
+                for missing_file in list(missing_files)[:3]:  # Check first 3
+                    normalized = normalize_filename(missing_file)
+                    if normalized != missing_file and normalized in files_found:
+                        suggestions.append(f"  '{missing_file}' → '{normalized}'")
+                
+                suggestion_text = ""
+                if suggestions:
+                    suggestion_text = f"\n🔧 File name normalization suggestions:\n" + "\n".join(suggestions)
+                
+                return f"""❌ Error: These files in attribute_values don't exist in CSV: {missing_list}
+
+📁 Sample files that DO exist in CSV:
+  {sample_list}{suggestion_text}
+
+💡 Tip: Use 'Inspect CSV Tool' to see all file names in the CSV, then use EXACT file names."""
+            
+            # Write updated CSV
+            with open(csv_path, 'w', newline='', encoding='utf-8') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=existing_fieldnames)
+                writer.writeheader()
+                writer.writerows(existing_data)
+            
+            return f"✅ Successfully added '{attribute_name}' column to {files_updated}/{len(existing_data)} files in {csv_path}"
+            
+        except Exception as e:
+            return f"❌ Failed to add annotation column: {str(e)}"
+
+
+class InspectCSVInput(BaseModel):
+    """Input for inspecting CSV file contents."""
+    csv_path: str = Field(description="Path to the CSV file to inspect")
+
+
+class InspectCSVTool(BaseTool):
+    name: str = "Inspect CSV Tool"
+    description: str = (
+        "Inspects a CSV file and shows its structure, column names, and first few rows. "
+        "Useful for debugging file name mismatches and understanding CSV contents."
+    )
+    args_schema: Type[BaseModel] = InspectCSVInput
+
+    def _run(self, csv_path: str) -> str:
+        """
+        Inspects a CSV file and returns information about its structure.
+        
+        Args:
+            csv_path: Path to CSV file to inspect
+            
+        Returns:
+            String with CSV information
+        """
+        try:
+            if not os.path.exists(csv_path):
+                return f"Error: CSV file not found at {csv_path}"
+            
+            # Read CSV
+            with open(csv_path, 'r', encoding='utf-8') as csvfile:
+                reader = csv.DictReader(csvfile)
+                fieldnames = list(reader.fieldnames or [])
+                rows = list(reader)
+            
+            if not rows:
+                return f"CSV file at {csv_path} is empty (no data rows)"
+            
+            # Get file info
+            file_size = os.path.getsize(csv_path)
+            
+            # Show first few file names for debugging
+            file_names = [row.get('file_name', '') for row in rows[:10]]
+            file_names_str = '\n  '.join(file_names)
+            
+            # Check for any unusual file names and normalization opportunities
+            unusual_names = []
+            normalization_suggestions = []
+            
+            for row in rows:
+                file_name = row.get('file_name', '')
+                if not file_name:
+                    continue
+                    
+                # Check for unusual patterns
+                if '.' not in file_name:
+                    unusual_names.append(file_name)
+                elif file_name.count('.') == 1 and not file_name.endswith('.gz'):
+                    unusual_names.append(file_name)
+                
+                # Check for normalization opportunities
+                normalized = normalize_filename(file_name)
+                if normalized != file_name:
+                    normalization_suggestions.append(f"  '{file_name}' → '{normalized}'")
+            
+            unusual_str = ""
+            if unusual_names:
+                unusual_str = f"\n\n⚠️  Unusual file names found (missing extensions or dots):\n  " + '\n  '.join(unusual_names[:5])
+            
+            normalization_str = ""
+            if normalization_suggestions:
+                normalization_str = f"\n\n🔧 File name normalization suggestions:\n" + '\n'.join(normalization_suggestions[:5])
+            
+            return f"""📄 CSV File Inspection: {csv_path}
+📊 Structure:
+  - Columns: {', '.join(fieldnames)}
+  - Total rows: {len(rows)}
+  - File size: {file_size} bytes
+
+📁 First 10 file names:
+  {file_names_str}{unusual_str}{normalization_str}
+
+💡 Tip: Use exact file names from this list when adding annotation columns."""
+            
+        except Exception as e:
+            return f"❌ Failed to inspect CSV: {str(e)}"
+
+
 class ApplyAnnotationsFromCSVInput(BaseModel):
     """Input for applying annotations from CSV to Synapse."""
     csv_path: str = Field(description="Path to the completed annotation CSV file")
@@ -899,3 +1338,317 @@ class ApplyAnnotationsFromCSVTool(BaseTool):
             
         except Exception as e:
             return f"Failed to apply annotations from CSV: {str(e)}" 
+
+
+class AnnotationValidationInput(BaseModel):
+    """Input for validating an annotation CSV against the data model."""
+    csv_path: str = Field(description="Path to the annotation CSV file.")
+    data_model_url: str = Field(
+        default="https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld",
+        description="URL or path to the JSON-LD data model"
+    )
+
+class AnnotationValidationTool(BaseTool):
+    name: str = "Annotation Validation Tool"
+    description: str = (
+        "Validates an annotation CSV against the data model. "
+        "It checks each column to ensure that the values are valid according to the data model."
+    )
+    args_schema: type[BaseModel] = AnnotationValidationInput
+
+    def _run(self, csv_path: str, data_model_url: str) -> str:
+        try:
+            jsonld_data = _load_jsonld(data_model_url)
+            
+            # Load the CSV
+            with open(csv_path, 'r') as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+                if not rows:
+                    return "CSV is empty. Nothing to validate."
+                headers = reader.fieldnames
+
+            errors = []
+            
+            all_attribute_labels = self._get_all_attribute_labels(jsonld_data)
+
+            for header in headers:
+                if header not in all_attribute_labels:
+                    continue
+
+                # Get valid values for the attribute
+                try:
+                    valid_values = self._get_valid_values(data_model_url, header)
+                    if not valid_values:
+                        continue # No validation possible if no values are defined
+                except Exception as e:
+                    errors.append(f"Could not get valid values for '{header}': {e}")
+                    continue
+
+                # Check each value in the column
+                for i, row in enumerate(rows):
+                    value = row.get(header)
+                    if value and value not in valid_values:
+                        valid_values_snippet = valid_values[:5]
+                        error_msg = f"Row {i+2}: Invalid value '{value}' for column '{header}'. Valid values include: {valid_values_snippet}"
+                        if len(valid_values) > 5:
+                            error_msg += "..."
+                        errors.append(error_msg)
+            
+            if errors:
+                return "Validation failed with the following errors:\n" + "\n".join(errors)
+            else:
+                return "Annotation CSV is valid."
+
+        except Exception as e:
+            return f"An error occurred during validation: {str(e)}"
+
+    def _get_all_attribute_labels(self, jsonld_data: dict) -> List[str]:
+        """Gets all valid attribute labels from the data model."""
+        labels = []
+        graph = jsonld_data.get('@graph', [])
+        for item in graph:
+            if isinstance(item, dict) and item.get('@type') == 'rdf:Property':
+                label = item.get('sms:displayName', item.get('rdfs:label'))
+                if label:
+                    labels.append(label)
+        return labels
+
+    def _get_valid_values(self, data_model_url: str, attribute_name: str) -> List[str]:
+        """Helper function to get valid values for an attribute."""
+        try:
+            # Use the existing tool to get valid values
+            valid_values_tool = JsonLdGetValidValuesTool()
+            results = valid_values_tool._run(source=data_model_url, attribute_name=attribute_name)
+            
+            # Extract just the values from the results
+            if isinstance(results, list) and results:
+                # Handle cases where values are in a 'name' or 'label' field
+                if isinstance(results[0], dict):
+                    return [item.get('name', item.get('label', '')) for item in results]
+                else:
+                    return [str(item) for item in results]
+            return []
+        except Exception:
+            return []
+
+
+class CreateAnnotationTemplateCSVInput(BaseModel):
+    """Input for creating an annotation template CSV."""
+    data_files_path: str = Field(description="Path to the JSON file containing the list of data files to include in the CSV.")
+    template_name: str = Field(description="Name of the template to use (e.g., 'RNASeqTemplate').")
+    output_path: str = Field(description="Path to save the generated CSV file.")
+    data_model_url: str = Field(
+        default="https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld",
+        description="URL or path to the JSON-LD data model"
+    )
+
+class CreateAnnotationTemplateCSVTool(BaseTool):
+    name: str = "Create Annotation Template CSV Tool"
+    description: str = (
+        "Creates a complete but empty annotation CSV from a template. "
+        "It uses the file list from the path provided by the 'Synapse Folder Analysis Tool'. "
+        "The CSV will have all the required columns for the specified template."
+    )
+    args_schema: Type[BaseModel] = CreateAnnotationTemplateCSVInput
+
+    def _run(self, data_files_path: str, template_name: str, output_path: str, data_model_url: str = "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld") -> str:
+        try:
+            with open(data_files_path, 'r') as f:
+                data_files = json.load(f)
+
+            jsonld_data = _load_jsonld(data_model_url)
+            template_attributes = self._get_template_attributes(jsonld_data, template_name)
+
+            if not template_attributes:
+                return f"Error: Template '{template_name}' not found or has no attributes."
+
+            fieldnames = ['synapse_id', 'file_name', 'Component'] + [attr['label'] for attr in template_attributes]
+            
+            with open(output_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                for file_info in data_files:
+                    row = {
+                        'synapse_id': file_info['id'],
+                        'file_name': file_info['name'],
+                        'Component': template_name
+                    }
+                    for attr in template_attributes:
+                        row[attr['label']] = ''
+                    writer.writerow(row)
+            
+            return f"Successfully created annotation template CSV at '{output_path}' with {len(data_files)} files and columns: {', '.join(fieldnames)}"
+        except Exception as e:
+            return f"Error creating annotation template CSV: {e}"
+
+    def _get_template_attributes(self, jsonld_data: dict, template_name: str) -> list:
+        """Get all attributes for a specific template from the data model."""
+        attributes = []
+        template_node = None
+        
+        # Find the template node by its label
+        for item in jsonld_data.get('@graph', []):
+            if item.get('rdfs:label', '').lower() == template_name.lower():
+                template_node = item
+                break
+        
+        if not template_node:
+            return []
+
+        # Get attribute IDs from sms:requiresDependency
+        required_dependencies = template_node.get('sms:requiresDependency', [])
+        if not isinstance(required_dependencies, list):
+            required_dependencies = [required_dependencies]
+        
+        attribute_ids = [dep.get('@id') for dep in required_dependencies if isinstance(dep, dict) and '@id' in dep]
+
+        # Look up each attribute's details
+        for attr_id in attribute_ids:
+            for item in jsonld_data.get('@graph', []):
+                if item.get('@id') == attr_id:
+                    attributes.append({
+                        'id': attr_id,
+                        'label': item.get('sms:displayName', item.get('rdfs:label', '')),
+                        'description': item.get('rdfs:comment', '')
+                    })
+                    break
+        
+        return attributes
+
+class UpdateAnnotationColumnInput(BaseModel):
+    """Input for updating a column in the annotation CSV."""
+    csv_path: str = Field(description="Path to the annotation CSV file.")
+    column_name: str = Field(description="The name of the column to update.")
+    default_value: Optional[str] = Field(None, description="A default value to apply to all rows.")
+    value_map: Optional[Dict[str, str]] = Field(None, description="A dictionary mapping 'file_name' to a specific value for that file.")
+
+class UpdateAnnotationColumnTool(BaseTool):
+    name: str = "Update Annotation Column Tool"
+    description: str = (
+        "Updates a single column in the annotation CSV. "
+        "You can either provide a default value for all rows or a map of file-specific values."
+    )
+    args_schema: Type[BaseModel] = UpdateAnnotationColumnInput
+
+    def _run(self, csv_path: str, column_name: str, default_value: Optional[str] = None, value_map: Optional[Dict[str, str]] = None) -> str:
+        try:
+            with open(csv_path, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+                fieldnames = reader.fieldnames
+
+            if column_name not in fieldnames:
+                return f"Error: Column '{column_name}' not found in CSV."
+
+            for row in rows:
+                if value_map and row['file_name'] in value_map:
+                    row[column_name] = value_map[row['file_name']]
+                elif default_value is not None:
+                    row[column_name] = default_value
+
+            with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+            return f"Successfully updated column '{column_name}' in '{csv_path}'."
+        except Exception as e:
+            return f"Error updating annotation column: {e}" 
+
+
+class BatchUpdateAnnotationsInput(BaseModel):
+    """Input for batch updating multiple columns in the annotation CSV."""
+    csv_path: str = Field(description="Path to the annotation CSV file.")
+    updates: Dict[str, str] = Field(description="A dictionary where keys are column names and values are the default values to apply.")
+
+class BatchUpdateAnnotationsTool(BaseTool):
+    name: str = "Batch Update Annotations Tool"
+    description: str = (
+        "Updates multiple columns in the annotation CSV with default values in a single batch. "
+        "This is much more efficient than updating one column at a time."
+    )
+    args_schema: Type[BaseModel] = BatchUpdateAnnotationsInput
+
+    def _run(self, csv_path: str, updates: Dict[str, str]) -> str:
+        try:
+            with open(csv_path, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+                fieldnames = reader.fieldnames
+
+            if not fieldnames:
+                return "Error: CSV has no headers."
+
+            for col_name in updates.keys():
+                if col_name not in fieldnames:
+                    return f"Error: Column '{col_name}' not found in CSV."
+
+            for row in rows:
+                for col_name, default_value in updates.items():
+                    row[col_name] = default_value
+
+            with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+            updated_columns = ", ".join(updates.keys())
+            return f"Successfully batch updated columns '{updated_columns}' in '{csv_path}'."
+        except Exception as e:
+            return f"Error during batch update: {e}" 
+
+
+class ReadFileHeaderInput(BaseModel):
+    """Input for reading the header of a file from Synapse."""
+    synapse_id: str = Field(description="The Synapse ID of the file to read.")
+    num_lines: int = Field(default=5, description="The number of lines to read from the beginning of the file.")
+
+class ReadFileHeaderTool(BaseTool):
+    name: str = "Read File Header Tool"
+    description: str = (
+        "Reads the first few lines of a file from Synapse, including compressed files. "
+        "Useful for inspecting file headers for metadata, such as SRA identifiers in FASTQ files."
+    )
+    args_schema: Type[BaseModel] = ReadFileHeaderInput
+    syn: Optional[synapseclient.Synapse] = None
+
+    def __init__(self, syn: synapseclient.Synapse, **kwargs):
+        super().__init__(**kwargs)
+        self.syn = syn
+
+    def _run(self, synapse_id: str, num_lines: int = 5) -> str:
+        import gzip
+        import tempfile
+        import os
+
+        if not self.syn:
+            return "Error: Synapse client not initialized."
+            
+        try:
+            file_entity = self.syn.get(synapse_id, downloadLocation=tempfile.gettempdir())
+            file_path = file_entity.path
+            
+            header_lines = []
+            
+            try:
+                if file_path.endswith('.gz'):
+                    with gzip.open(file_path, 'rt', encoding='utf-8') as f:
+                        for i, line in enumerate(f):
+                            if i >= num_lines:
+                                break
+                            header_lines.append(line.strip())
+                else:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        for i, line in enumerate(f):
+                            if i >= num_lines:
+                                break
+                            header_lines.append(line.strip())
+            finally:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+            
+            return "\\n".join(header_lines)
+            
+        except Exception as e:
+            return f"Error reading file header for {synapse_id}: {e}" 

--- a/src/tools/synapse_tools.py
+++ b/src/tools/synapse_tools.py
@@ -1,12 +1,14 @@
 import synapseclient
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
-from typing import Type, Optional, List
+from typing import Type, Optional, List, Any, Dict
 import io
 import sys
 import pandas as pd
 from contextlib import redirect_stdout
 import os
+import json
+import tempfile
 
 
 class CodeSnippetInput(BaseModel):
@@ -552,34 +554,273 @@ class SynapseBatchAnnotationTool(BaseTool):
         results = []
         failed = []
         
-        for annotation_spec in annotations:
-            try:
-                entity_id = annotation_spec['entity_id']
-                annotation_dict = annotation_spec['annotations']
-                
-                # Get the entity without downloading the file
-                entity = self.syn.get(entity_id, downloadFile=False)
-                
-                # Apply the annotations
-                entity.annotations = annotation_dict
-                
-                # Store the updated entity  
-                updated_entity = self.syn.store(entity, forceVersion=False)
-                
-                results.append(f"Applied annotations to '{updated_entity.name}' (ID: {updated_entity.id})")
-                
-            except Exception as e:
-                failed.append(f"Failed to annotate '{annotation_spec.get('entity_id', 'unknown')}': {e}")
+        # Process in batches to handle large numbers of files efficiently
+        batch_size = 25  # Process 25 files at a time to avoid parameter size limits
+        total_batches = (len(annotations) + batch_size - 1) // batch_size
+        
+        for batch_num in range(total_batches):
+            start_idx = batch_num * batch_size
+            end_idx = min(start_idx + batch_size, len(annotations))
+            batch_annotations = annotations[start_idx:end_idx]
+            
+            print(f"Processing batch {batch_num + 1}/{total_batches} ({len(batch_annotations)} files)...")
+            
+            for annotation_spec in batch_annotations:
+                try:
+                    entity_id = annotation_spec['entity_id']
+                    annotation_dict = annotation_spec['annotations']
+                    
+                    # Get the entity without downloading the file
+                    entity = self.syn.get(entity_id, downloadFile=False)
+                    
+                    # Apply the annotations
+                    entity.annotations = annotation_dict
+                    
+                    # Store the updated entity  
+                    updated_entity = self.syn.store(entity, forceVersion=False)
+                    
+                    results.append(f"Applied annotations to '{updated_entity.name}' (ID: {updated_entity.id})")
+                    
+                except Exception as e:
+                    failed.append(f"Failed to annotate '{annotation_spec.get('entity_id', 'unknown')}': {e}")
         
         summary = f"Successfully applied annotations to {len(results)} entities"
         if failed:
             summary += f", {len(failed)} failed"
         
-        summary += ":\n" + "\n".join(results)
+        # For large batches, provide a summary instead of listing all files
+        if len(results) > 20:
+            summary += f"\n\nProcessed {len(results)} files across {total_batches} batches."
+            if len(results) <= 50:  # Show first few and last few for medium lists
+                summary += "\n\nFirst few files:\n" + "\n".join(results[:10])
+                if len(results) > 10:
+                    summary += f"\n... and {len(results) - 10} more files"
+        else:
+            summary += ":\n" + "\n".join(results)
+            
         if failed:
             summary += "\n\nFailures:\n" + "\n".join(failed)
         
         return summary
+
+
+class LargeBatchAnnotationInput(BaseModel):
+    """Input for applying large batches of annotations from a file."""
+    annotation_file_path: str = Field(description="Path to JSON file containing annotations list")
+
+class SynapseLargeBatchAnnotationTool(BaseTool):
+    name: str = "apply_large_batch_annotations"
+    description: str = (
+        "Applies annotations to large numbers of Synapse entities by reading from a JSON file. "
+        "This tool is designed for processing hundreds of files efficiently without parameter size limits. "
+        "The JSON file should contain a list of annotation specifications with 'entity_id' and 'annotations' fields."
+    )
+    args_schema: Type[BaseModel] = LargeBatchAnnotationInput
+    syn: Optional[synapseclient.Synapse] = None
+
+    def __init__(self, syn: synapseclient.Synapse, **kwargs):
+        super().__init__(**kwargs)
+        self.syn = syn
+
+    def _run(self, annotation_file_path: str) -> str:
+        """
+        Applies annotations to multiple Synapse entities from a JSON file.
+        
+        Args:
+            annotation_file_path: Path to JSON file containing annotations
+            
+        Returns:
+            Status message with results or error details
+        """
+        if not self.syn:
+            return "Synapse client not initialized. Login failed."
+        
+        if not os.path.exists(annotation_file_path):
+            return f"Annotation file not found: {annotation_file_path}"
+        
+        try:
+            with open(annotation_file_path, 'r') as f:
+                annotations = json.load(f)
+        except Exception as e:
+            return f"Error reading annotation file: {e}"
+        
+        if not annotations:
+            return "No annotations found in file."
+        
+        results = []
+        failed = []
+        
+        # Process in batches to handle large numbers of files efficiently
+        batch_size = 25  # Process 25 files at a time
+        total_batches = (len(annotations) + batch_size - 1) // batch_size
+        
+        print(f"Starting large batch annotation process: {len(annotations)} files in {total_batches} batches")
+        
+        for batch_num in range(total_batches):
+            start_idx = batch_num * batch_size
+            end_idx = min(start_idx + batch_size, len(annotations))
+            batch_annotations = annotations[start_idx:end_idx]
+            
+            print(f"Processing batch {batch_num + 1}/{total_batches} ({len(batch_annotations)} files)...")
+            
+            batch_results = 0
+            for annotation_spec in batch_annotations:
+                try:
+                    entity_id = annotation_spec['entity_id']
+                    annotation_dict = annotation_spec['annotations']
+                    
+                    # Get the entity without downloading the file
+                    entity = self.syn.get(entity_id, downloadFile=False)
+                    
+                    # Apply the annotations
+                    entity.annotations = annotation_dict
+                    
+                    # Store the updated entity  
+                    updated_entity = self.syn.store(entity, forceVersion=False)
+                    
+                    results.append(f"Applied annotations to '{updated_entity.name}' (ID: {updated_entity.id})")
+                    batch_results += 1
+                    
+                except Exception as e:
+                    failed.append(f"Failed to annotate '{annotation_spec.get('entity_id', 'unknown')}': {e}")
+            
+            print(f"Batch {batch_num + 1} completed: {batch_results}/{len(batch_annotations)} successful")
+        
+        summary = f"Large batch annotation completed!\n"
+        summary += f"Successfully applied annotations to {len(results)} entities"
+        if failed:
+            summary += f", {len(failed)} failed"
+        
+        summary += f"\n\nProcessed {len(annotations)} total files across {total_batches} batches."
+        
+        # Show sample of successful annotations
+        if len(results) > 0:
+            summary += "\n\nSample of annotated files:\n" + "\n".join(results[:5])
+            if len(results) > 5:
+                summary += f"\n... and {len(results) - 5} more files"
+            
+        if failed:
+            summary += f"\n\nFailures ({len(failed)}):\n" + "\n".join(failed[:10])
+            if len(failed) > 10:
+                summary += f"\n... and {len(failed) - 10} more failures"
+        
+        return summary
+
+
+class FolderAnnotationInput(BaseModel):
+    """Input for annotating files in a single folder."""
+    folder_id: str = Field(description="Synapse ID of the folder to annotate")
+    annotations_dict: Dict[str, Any] = Field(description="Dictionary of annotations to apply to all files in the folder")
+
+class SynapseFolderAnnotationTool(BaseTool):
+    name: str = "annotate_folder"
+    description: str = (
+        "Applies the same set of annotations to all data files within a single Synapse folder. "
+        "This tool is designed for incremental processing where each folder represents a logical "
+        "group (e.g., all files from one SRR experiment). Only annotates actual data files, "
+        "skipping metadata and auxiliary files. The 'Filename' field is automatically added "
+        "to each file's annotations, but all other annotation decisions are made by the LLM."
+    )
+    args_schema: Type[BaseModel] = FolderAnnotationInput
+    syn: Optional[synapseclient.Synapse] = None
+
+    def __init__(self, syn: synapseclient.Synapse, **kwargs):
+        super().__init__(**kwargs)
+        self.syn = syn
+
+    def _run(self, folder_id: str, annotations_dict: Dict[str, Any]) -> str:
+        """
+        Applies annotations to all data files in a specific folder.
+        
+        Args:
+            folder_id: Synapse ID of the folder
+            annotations_dict: Annotations to apply to all files
+            
+        Returns:
+            Status message with results or error details
+        """
+        if not self.syn:
+            return "Synapse client not initialized. Login failed."
+        
+        if not annotations_dict:
+            return "No annotations provided."
+        
+        try:
+            # Get folder entity
+            folder_entity = self.syn.get(folder_id, downloadFile=False)
+            
+            # Get all files in the folder
+            children = list(self.syn.getChildren(folder_id, includeTypes=["file"]))
+            
+            if not children:
+                return f"No files found in folder {folder_entity.name} ({folder_id})"
+            
+            # Filter for data files (exclude metadata files)
+            data_files = []
+            for child in children:
+                child_name = child['name'].lower()
+                # Include common data file extensions, exclude metadata
+                if (child_name.endswith(('.fastq.gz', '.fastq', '.fq.gz', '.fq', '.bam', '.sam', 
+                                       '.cram', '.vcf.gz', '.vcf', '.bed', '.bedgraph', '.bigwig', 
+                                       '.bw', '.wig', '.txt', '.tsv', '.csv')) and 
+                    not any(metadata_term in child_name for metadata_term in 
+                           ['metadata', 'readme', 'manifest', 'summary', 'info', 'log'])):
+                    data_files.append(child)
+            
+            if not data_files:
+                return f"No data files found in folder {folder_entity.name} ({folder_id})"
+            
+            results = []
+            failed = []
+            
+            print(f"Annotating {len(data_files)} files in folder '{folder_entity.name}'...")
+            
+            for file_info in data_files:
+                try:
+                    file_id = file_info['id']
+                    file_name = file_info['name']
+                    
+                    # Get the file entity
+                    file_entity = self.syn.get(file_id, downloadFile=False)
+                    
+                    # Create a copy of annotations and add filename
+                    file_annotations = annotations_dict.copy()
+                    file_annotations['Filename'] = file_name
+                    
+                    # Apply the annotations
+                    file_entity.annotations = file_annotations
+                    
+                    # Store the updated entity
+                    updated_entity = self.syn.store(file_entity, forceVersion=False)
+                    
+                    results.append(f"✅ {file_name}")
+                    
+                except Exception as e:
+                    failed.append(f"❌ {file_info['name']}: {str(e)}")
+            
+            # Prepare summary
+            summary = f"Folder annotation completed for '{folder_entity.name}'"
+            summary += f"\nSuccessfully annotated: {len(results)} files"
+            
+            if failed:
+                summary += f"\nFailed: {len(failed)} files"
+            
+            # Show results
+            if len(results) <= 10:
+                summary += f"\n\nAnnotated files:\n" + "\n".join(results)
+            else:
+                summary += f"\n\nSample of annotated files:\n" + "\n".join(results[:5])
+                summary += f"\n... and {len(results) - 5} more files"
+            
+            if failed:
+                summary += f"\n\nFailures:\n" + "\n".join(failed[:5])
+                if len(failed) > 5:
+                    summary += f"\n... and {len(failed) - 5} more failures"
+            
+            return summary
+            
+        except Exception as e:
+            return f"Error processing folder {folder_id}: {str(e)}"
 
 
 def get_entity_children_recursively(syn: synapseclient.Synapse, synapse_id: str) -> pd.DataFrame:

--- a/src/tools/zooma_tools.py
+++ b/src/tools/zooma_tools.py
@@ -1,0 +1,52 @@
+import requests
+import json
+from crewai.tools import BaseTool
+from typing import Optional, Type
+from pydantic import BaseModel, Field
+
+
+class ZoomaInput(BaseModel):
+    """Input model for the ZOOMA Term Mapper tool."""
+    query: str = Field(description="The text to be annotated with an ontology term.")
+
+def _extract_short_uri(uri: str) -> str:
+    """Extracts the short form of a URI (e.g., 'NCIT_C3797')."""
+    return uri.split('/')[-1]
+
+class ZoomaTermMappingTool(BaseTool):
+    name: str = "ZOOMA Term Mapper"
+    description: str = "Maps a given text to the best-matching ontology term and URI using the ZOOMA API."
+    args_schema: Type[BaseModel] = ZoomaInput
+    llm: Optional[any] = None
+
+    def __init__(self, llm: any = None, **kwargs):
+        super().__init__(**kwargs)
+        if llm:
+            self.llm = llm
+
+    def _run(self, query: str) -> str:
+        """Use the ZOOMA API to find the best ontology term for a given text."""
+        base_url = "http://www.ebi.ac.uk/spot/zooma/v2/api"
+        endpoint = "/services/annotate"
+        params = {"propertyValue": query}
+
+        try:
+            response = requests.get(f"{base_url}{endpoint}", params=params)
+            response.raise_for_status()
+            results = response.json()
+
+            if not results:
+                return json.dumps({"error": "No ontology term found for the given query."})
+
+            best_match = results[0]
+            try:
+                term = best_match['derivedFrom']['annotatedProperty']['propertyValue']
+                uri = best_match['semanticTags'][0]
+                short_uri = _extract_short_uri(uri)
+                
+                return json.dumps({"term": term, "uri": short_uri})
+            except (KeyError, TypeError, IndexError):
+                return json.dumps({"error": "Could not extract term or URI from the API response."})
+
+        except requests.exceptions.RequestException as e:
+            return json.dumps({"error": f"An error occurred while calling the ZOOMA API: {e}"}) 

--- a/src/utils/annotation_utils.py
+++ b/src/utils/annotation_utils.py
@@ -1,0 +1,171 @@
+"""
+Utility functions for dataset annotation workflows.
+These functions help simplify common annotation patterns.
+"""
+
+import synapseclient
+from typing import List, Dict, Any
+import os
+import re
+
+
+def extract_file_types(file_list: List[Dict]) -> Dict[str, int]:
+    """
+    Extract and count file types from a list of file info dictionaries.
+    
+    Args:
+        file_list: List of file info dictionaries with 'name' field
+        
+    Returns:
+        Dictionary mapping file extensions to counts
+    """
+    file_types = {}
+    for file_info in file_list:
+        filename = file_info.get('name', '')
+        # Handle compressed files like .fastq.gz
+        if filename.endswith('.gz'):
+            # Get the extension before .gz
+            base_name = filename[:-3]
+            if '.' in base_name:
+                ext = '.' + base_name.split('.')[-1] + '.gz'
+            else:
+                ext = '.gz'
+        else:
+            ext = os.path.splitext(filename)[1].lower()
+        
+        if ext:
+            file_types[ext] = file_types.get(ext, 0) + 1
+    
+    return file_types
+
+
+def suggest_template_from_files(file_types: Dict[str, int], external_ids: Dict = None) -> str:
+    """
+    Suggest an appropriate template based on file types and external identifiers.
+    
+    Args:
+        file_types: Dictionary mapping file extensions to counts
+        external_ids: Dictionary of external identifiers found
+        
+    Returns:
+        Suggested template name
+    """
+    # Check for sequencing data
+    sequencing_extensions = {'.fastq.gz', '.fastq', '.fq.gz', '.fq', '.bam', '.sam'}
+    has_sequencing = any(ext in file_types for ext in sequencing_extensions)
+    
+    # Check for single-cell indicators
+    single_cell_indicators = ['10x', 'cellranger', 'single.cell', 'sc.rna', 'scrna']
+    
+    # Check for bulk RNA-seq indicators
+    bulk_rna_indicators = ['bulk', 'rna.seq', 'rnaseq']
+    
+    if has_sequencing:
+        # Check file names and external IDs for single-cell indicators
+        has_single_cell = False
+        if external_ids:
+            all_text = ' '.join(str(v).lower() for v in external_ids.values())
+            has_single_cell = any(indicator in all_text for indicator in single_cell_indicators)
+        
+        if has_single_cell:
+            return "ScRNASeqTemplate"
+        else:
+            return "RNASeqTemplate"  # Default for sequencing data
+    
+    # Check for other data types
+    if '.xlsx' in file_types or '.csv' in file_types:
+        return "DataTemplate"  # Generic template for tabular data
+    
+    # Default fallback
+    return "DataTemplate"
+
+
+def create_basic_annotations(template: str, file_info: Dict, additional_annotations: Dict = None) -> Dict[str, Any]:
+    """
+    Create basic annotations for a file based on the template and file information.
+    
+    Args:
+        template: Template name to use
+        file_info: File information dictionary
+        additional_annotations: Additional annotations to include
+        
+    Returns:
+        Dictionary of annotations
+    """
+    annotations = {}
+    
+    # Basic annotations for all templates
+    filename = file_info.get('name', '')
+    file_size = file_info.get('contentSize', 0)
+    
+    # Set basic required fields
+    annotations['Component'] = 'DataFile'
+    annotations['Filename'] = filename
+    
+    # Set file format based on extension
+    if filename.endswith('.fastq.gz') or filename.endswith('.fq.gz'):
+        annotations['fileFormat'] = 'fastq'
+    elif filename.endswith('.fastq') or filename.endswith('.fq'):
+        annotations['fileFormat'] = 'fastq'
+    elif filename.endswith('.bam'):
+        annotations['fileFormat'] = 'bam'
+    elif filename.endswith('.sam'):
+        annotations['fileFormat'] = 'sam'
+    elif filename.endswith('.csv'):
+        annotations['fileFormat'] = 'csv'
+    elif filename.endswith('.xlsx'):
+        annotations['fileFormat'] = 'excel'
+    else:
+        # Try to infer from extension
+        ext = os.path.splitext(filename)[1].lower()
+        if ext:
+            annotations['fileFormat'] = ext[1:]  # Remove the dot
+    
+    # Template-specific annotations
+    if template == "RNASeqTemplate" or template == "ScRNASeqTemplate":
+        annotations['resourceType'] = 'experimentalData'
+        annotations['dataType'] = 'geneExpression'
+        annotations['assay'] = 'rnaSeq'
+        annotations['species'] = 'Homo sapiens'  # Default, should be updated based on actual data
+        annotations['platform'] = 'Illumina'  # Default, should be updated based on actual data
+        
+        if template == "ScRNASeqTemplate":
+            annotations['dataSubtype'] = 'raw'
+            # Single-cell specific annotations could be added here
+        else:
+            annotations['dataSubtype'] = 'raw'
+    
+    # Add any additional annotations
+    if additional_annotations:
+        annotations.update(additional_annotations)
+    
+    return annotations
+
+
+def prepare_batch_annotations(data_files: List[Dict], template: str, common_annotations: Dict = None) -> List[Dict]:
+    """
+    Prepare a list of annotation specifications for batch application.
+    
+    Args:
+        data_files: List of file information dictionaries
+        template: Template name to use for all files
+        common_annotations: Common annotations to apply to all files
+        
+    Returns:
+        List of annotation specifications for SynapseBatchAnnotationTool
+    """
+    batch_annotations = []
+    
+    for file_info in data_files:
+        entity_id = file_info.get('id')
+        if not entity_id:
+            continue
+            
+        annotations = create_basic_annotations(template, file_info, common_annotations)
+        
+        batch_annotations.append({
+            'entity_id': entity_id,
+            'annotations': annotations
+        })
+    
+    return batch_annotations 

--- a/src/utils/cli_utils.py
+++ b/src/utils/cli_utils.py
@@ -1,0 +1,78 @@
+import synapseclient
+
+def prompt_for_view_and_column(syn: synapseclient.Synapse, views: dict):
+    """
+    Prompts the user to select a Synapse view/table and a column.
+
+    Args:
+        syn: An authenticated Synapse client.
+        views: A dictionary of available views from the config.
+
+    Returns:
+        A tuple of (view_synapse_id, column_name, row_id_col) or (None, None, None) if the user cancels.
+    """
+    # Prompt user to select a table
+    view_choices = list(views.keys())
+    if not view_choices:
+        print("No views configured in config.yaml. Exiting.")
+        return None, None, None
+
+    print("\\nPlease select a table to work on:")
+    for i, view_name in enumerate(view_choices):
+        print(f"{i+1}. {view_name} ({views[view_name]})")
+
+    while True:
+        try:
+            choice = int(input("Enter the number of your choice: ")) - 1
+            if 0 <= choice < len(view_choices):
+                selected_view_name = view_choices[choice]
+                view_synapse_id = views[selected_view_name]
+                print(f"\\nYou have selected: {selected_view_name}")
+                break
+            else:
+                print("Invalid choice. Please enter a number from the list.")
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+
+    # Get columns for the selected view
+    try:
+        view = syn.get(view_synapse_id)
+        columns = [c['name'] for c in syn.getColumns(view)]
+    except Exception as e:
+        print(f"Error fetching columns for view '{view_synapse_id}': {e}")
+        return None, None, None
+
+    # Ask user for the column name to process
+    print("\\nAvailable columns to process:")
+    for i, col in enumerate(columns):
+        print(f"{i+1}. {col}")
+    
+    while True:
+        try:
+            choice = int(input("Enter the number of the column you want to process: ")) - 1
+            if 0 <= choice < len(columns):
+                column_name = columns[choice]
+                break
+            else:
+                print("Invalid choice. Please enter a number from the list.")
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+
+    # Ask user for the row identifier column
+    print("\\nPlease select the column that uniquely identifies rows (e.g., ROW_ID):")
+    for i, col in enumerate(columns):
+        print(f"{i+1}. {col}")
+
+    while True:
+        try:
+            choice = int(input("Enter the number of the identifier column: ")) - 1
+            if 0 <= choice < len(columns):
+                row_id_col = columns[choice]
+                print(f"Using '{row_id_col}' as the row identifier.")
+                break
+            else:
+                print("Invalid choice. Please enter a number from the list.")
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+            
+    return view_synapse_id, column_name, row_id_col 

--- a/src/utils/llm_utils.py
+++ b/src/utils/llm_utils.py
@@ -1,17 +1,22 @@
 import yaml
 from crewai import LLM
 import os
+import time
+import random
 
-def get_llm():
+def get_llm(agent_name: str = None, config: dict = None):
     """
-    Initializes and returns the LLM based on the configuration in config.yaml and creds.yaml.
+    Initializes and returns the LLM based on the provided configuration.
+    If an agent_name is given, it will look for a specific model for that agent
+    (e.g., 'ontology_expert_model') and fall back to the base 'model' if not found.
     """
-    try:
-        with open('config.yaml', 'r') as f:
-            config = yaml.safe_load(f).get('llm', {})
-    except (FileNotFoundError, yaml.YAMLError):
-        print("Warning: Could not read or parse config.yaml. Relying on environment variables.")
-        config = {}
+    if config is None:
+        try:
+            with open('config.yaml', 'r') as f:
+                config = yaml.safe_load(f).get('llm', {})
+        except (FileNotFoundError, yaml.YAMLError):
+            print("Warning: Could not read or parse config.yaml. Relying on environment variables.")
+            config = {}
     
     try:
         with open('creds.yaml', 'r') as f:
@@ -26,8 +31,90 @@ def get_llm():
     for key, value in credentials.items():
         os.environ[key] = value
 
-    model_name = config.get('model')
-    if not model_name:
-        raise ValueError("LLM model not specified in config.yaml")
+    # CrewAI's openrouter tool expects OPENAI_API_KEY. If OPENROUTER_API_KEY is provided,
+    # set OPENAI_API_KEY to its value for compatibility.
+    if 'OPENROUTER_API_KEY' in os.environ:
+        os.environ['OPENAI_API_KEY'] = os.environ['OPENROUTER_API_KEY']
 
-    return LLM(model=model_name) 
+    # Determine the model name with agent-specific fallback
+    model_name = None
+    if agent_name:
+        agent_config = config.get('agents', {}).get(agent_name, {})
+        model_name = agent_config.get('model')
+
+    if not model_name:
+        model_name = config.get('model')
+
+    if not model_name:
+        raise ValueError("LLM model not specified in config.yaml or as an agent-specific model.")
+
+    print(f"🤖  Using model: {model_name} for agent: {agent_name or 'default'}")
+    return LLM(model=model_name)
+
+
+def crew_kickoff_with_retry(crew, max_retries=3, base_delay=2, max_delay=10, context="operation"):
+    """
+    Executes crew.kickoff() with retry logic for LLM failures.
+    
+    Args:
+        crew: The CrewAI crew instance to execute
+        max_retries: Maximum number of retry attempts (default: 3)
+        base_delay: Base delay in seconds between retries (default: 2)
+        max_delay: Maximum delay in seconds (default: 10)
+        context: Description of the operation for logging (default: "operation")
+    
+    Returns:
+        The result from crew.kickoff()
+    
+    Raises:
+        The last exception encountered if all retries fail
+    """
+    for attempt in range(max_retries):
+        try:
+            result = crew.kickoff()
+            # Check if the result is valid (not None or empty)
+            if result is None:
+                raise ValueError("Invalid response from LLM call - None result")
+            
+            # Check if result has expected attributes
+            if hasattr(result, 'raw'):
+                if not result.raw or result.raw.strip() == "":
+                    raise ValueError("Invalid response from LLM call - empty raw content")
+            elif isinstance(result, str):
+                if not result.strip():
+                    raise ValueError("Invalid response from LLM call - empty string result")
+            
+            # If we got here, the result appears valid
+            return result
+            
+        except Exception as e:
+            is_retry_worthy = (
+                "Invalid response from LLM call" in str(e) or
+                "None or empty" in str(e) or
+                "RemoteProtocolError" in str(e) or
+                "peer closed connection" in str(e) or
+                "ConnectionError" in str(e) or
+                "Timeout" in str(e) or
+                "rate limit" in str(e).lower() or
+                "502" in str(e) or
+                "503" in str(e) or
+                "504" in str(e)
+            )
+            
+            if not is_retry_worthy or attempt == max_retries - 1:
+                # Either not worth retrying or this was the last attempt
+                if attempt == max_retries - 1:
+                    print(f"❌ Failed to complete {context} after {max_retries} attempts. Last error: {e}")
+                else:
+                    print(f"❌ Non-retryable error in {context}: {e}")
+                raise e
+            
+            # Calculate delay with exponential backoff and jitter
+            delay = min(base_delay * (2 ** attempt) + random.uniform(0, 1), max_delay)
+            
+            print(f"⚠️  {context} failed (attempt {attempt + 1}/{max_retries}): {e}")
+            print(f"🔄 Retrying in {delay:.1f} seconds...")
+            time.sleep(delay)
+    
+    # This should never be reached, but just in case
+    raise RuntimeError(f"Unexpected failure in retry logic for {context}") 

--- a/src/utils/synapse_utils.py
+++ b/src/utils/synapse_utils.py
@@ -1,0 +1,96 @@
+import synapseclient
+from synapseclient import Table
+import pandas as pd
+
+def update_table_column_with_corrections(
+    syn: synapseclient.Synapse, 
+    table_id: str, 
+    column_name: str, 
+    corrections: list[dict]
+):
+    """
+    Updates a single column in a Synapse table based on a list of corrections.
+
+    This function will:
+    1. Query for the specific rows that need updating.
+    2. Apply the corrections to the queried data.
+    3. Store the changes back to Synapse.
+
+    Args:
+        syn: An authenticated Synapse client instance.
+        table_id: The Synapse ID of the table/view to update.
+        column_name: The name of the column to update.
+        corrections: A list of dictionaries, where each dict has
+                     'current_value' and 'new_value' keys.
+    """
+    if not corrections:
+        print(f"No corrections provided for column '{column_name}'.")
+        return
+
+    # Separate None values from string values for the WHERE clause
+    current_values = [c['current_value'] for c in corrections]
+    string_values = [f"'{v}'" for v in current_values if v is not None]
+    
+    where_clauses = []
+    if string_values:
+        where_clauses.append(f'"{column_name}" IN ({", ".join(string_values)})')
+    if None in current_values:
+        where_clauses.append(f'"{column_name}" IS NULL')
+    
+    if not where_clauses:
+        print("No values to query for update.")
+        return
+
+    # Query for the rows to be updated to get their current state, ROW_ID, and ROW_VERSION
+    query = f'SELECT "{column_name}" FROM {table_id} WHERE {" OR ".join(where_clauses)}'
+    
+    try:
+        results = syn.tableQuery(query, includeRowIdAndRowVersion=True)
+        updates_df = results.asDataFrame(convert_to_datetime=True)
+
+        if updates_df.empty:
+            print(f"Warning: Query for values to update in '{column_name}' returned no rows.")
+            return
+
+        # Create a mapping from old value to new value for efficient lookup
+        correction_map = {c['current_value']: c['new_value'] for c in corrections}
+
+        # Apply the corrections to the DataFrame using replace.
+        # .replace is safer than .map as it leaves unmapped values (including NaN) untouched.
+        updates_df[column_name] = updates_df[column_name].replace(correction_map)
+
+        # Store the modified DataFrame back to Synapse
+        table_to_store = Table(table_id, updates_df)
+        syn.store(table_to_store)
+        
+        print(f"Successfully updated {len(updates_df)} rows for column '{column_name}' in table {table_id}.")
+
+    except Exception as e:
+        print(f"Error updating column '{column_name}' in Synapse table {table_id}: {e}")
+        import traceback
+        traceback.print_exc()
+
+def get_synapse_table_as_df(syn: synapseclient.Synapse, synapse_id: str) -> pd.DataFrame:
+    """
+    Queries a Synapse table or view and returns it as a pandas DataFrame.
+    """
+    try:
+        results = syn.tableQuery(f"SELECT * FROM {synapse_id}")
+        df = results.asDataFrame()
+        return df
+    except Exception as e:
+        print(f"Error querying table {synapse_id}: {e}")
+        return pd.DataFrame()
+
+def build_synapse_table(syn: synapseclient.Synapse, name: str, parent_id: str, columns: list) -> synapseclient.Table:
+    """
+    Builds a new Synapse Table with the given name, parent project/folder, and column schema.
+    """
+    try:
+        schema = synapseclient.Schema(name=name, parent=parent_id, columns=columns)
+        table = syn.store(schema)
+        print(f"Successfully created table '{name}' ({table.id}).")
+        return table
+    except Exception as e:
+        print(f"Error creating table '{name}': {e}")
+        return None 

--- a/src/workflows/correction.py
+++ b/src/workflows/correction.py
@@ -2,7 +2,7 @@ from crewai import Agent, Crew, Process, Task
 import yaml
 from ..agents.annotation_corrector import get_annotation_corrector_agent
 from ..agents.github_issue_filer import GitHubIssueFilerAgent
-from src.utils.llm_utils import get_llm
+from src.utils.llm_utils import get_llm, crew_kickoff_with_retry
 import os
 import synapseclient
 import json
@@ -90,7 +90,7 @@ class CorrectionWorkflow:
                 process=Process.sequential,
                 verbose=True
             )
-            plan_output = crew.kickoff()
+            plan_output = crew_kickoff_with_retry(crew, context="annotation correction plan")
             
             print(f"Agent's Raw Plan:\n{plan_output.raw}")
 

--- a/src/workflows/freetext_correction.py
+++ b/src/workflows/freetext_correction.py
@@ -11,6 +11,7 @@ import time
 import synapseclient
 import pandas as pd
 from src.utils.cli_utils import prompt_for_view_and_column
+from src.utils.llm_utils import crew_kickoff_with_retry
 
 class FreetextCorrectionWorkflow:
     def __init__(self, syn, llm, views, freetext_settings=None):
@@ -62,7 +63,8 @@ class FreetextCorrectionWorkflow:
             process=Process.sequential,
         )
 
-        selected_column = crew.kickoff().raw
+        result = crew_kickoff_with_retry(crew, context="column selection")
+        selected_column = result.raw
         
         # Validate that the agent returned a valid column name
         if selected_column.strip() in all_columns:
@@ -174,24 +176,13 @@ class FreetextCorrectionWorkflow:
             )
             
             corrected_text = value # Default to original value
-            max_retries = 3
-            for attempt in range(max_retries):
-                try:
-                    corrected_text_raw = crew.kickoff().raw
-                    corrected_text = self._parse_agent_output(corrected_text_raw)
-                    break  # Success
-                except Exception as e:
-                    # Catch network errors and retry
-                    if "RemoteProtocolError" in str(e) or "peer closed connection" in str(e):
-                        if attempt < max_retries - 1:
-                            print(f"\nNetwork error processing item. Retrying in 2 seconds... (Attempt {attempt + 2}/{max_retries})")
-                            time.sleep(2)
-                        else:
-                            print(f"\nFailed to process an item after {max_retries} attempts due to a network error. Skipping.")
-                    else:
-                        # For non-network errors, print and skip immediately
-                        print(f"\nAn unexpected error occurred: {e}. Skipping this item.")
-                        break
+            try:
+                result = crew_kickoff_with_retry(crew, context="freetext correction")
+                corrected_text_raw = result.raw
+                corrected_text = self._parse_agent_output(corrected_text_raw)
+            except Exception as e:
+                print(f"\nFailed to process text correction after retries: {e}. Skipping this item.")
+                corrected_text = value  # Keep original value on failure
 
             if corrected_text.strip() != value.strip():
                 # Only prompt for review if a meaningful diff exists

--- a/src/workflows/uncontrolled_vocab_normalization.py
+++ b/src/workflows/uncontrolled_vocab_normalization.py
@@ -12,6 +12,7 @@ import synapseclient
 import pandas as pd
 import json
 from src.utils.cli_utils import prompt_for_view_and_column
+from src.utils.llm_utils import crew_kickoff_with_retry
 
 class UncontrolledVocabNormalizationWorkflow:
     def __init__(self, syn, llm, views, orchestrator=None):
@@ -139,7 +140,8 @@ class UncontrolledVocabNormalizationWorkflow:
             process=Process.sequential
         )
         
-        raw_output = crew.kickoff().raw
+        result = crew_kickoff_with_retry(crew, context="vocabulary normalization")
+        raw_output = result.raw
         all_corrections = self._parse_agent_output(raw_output)
 
         # Filter out corrections where the original and corrected values are the same
@@ -510,7 +512,8 @@ class UncontrolledVocabNormalizationWorkflow:
             process=Process.sequential
         )
         
-        raw_output = crew.kickoff().raw
+        result = crew_kickoff_with_retry(crew, context="vocabulary normalization (full workflow)")
+        raw_output = result.raw
         all_corrections = self._parse_agent_output(raw_output)
 
         # Filter out corrections where the original and corrected values are the same

--- a/tests/tools/test_synapse_analysis_tools.py
+++ b/tests/tools/test_synapse_analysis_tools.py
@@ -1,0 +1,48 @@
+import unittest
+import json
+from unittest.mock import patch, mock_open
+from src.tools.synapse_analysis_tools import CreateAnnotationTemplateCSVTool
+
+class TestCreateAnnotationTemplateCSVTool(unittest.TestCase):
+
+    @patch('src.tools.synapse_analysis_tools._load_jsonld')
+    def test_get_template_attributes(self, mock_load_jsonld):
+        # Mock the JSON-LD data
+        mock_jsonld_data = {
+            "@graph": [
+                {
+                    "@id": "bts:RNASeqTemplate",
+                    "rdfs:label": "RNASeqTemplate",
+                    "sms:requiresDependency": [
+                        {"@id": "bts:Assay"},
+                        {"@id": "bts:DataType"}
+                    ]
+                },
+                {
+                    "@id": "bts:Assay",
+                    "rdfs:label": "Assay",
+                    "sms:displayName": "assay",
+                    "rdfs:comment": "The type of assay"
+                },
+                {
+                    "@id": "bts:DataType",
+                    "rdfs:label": "DataType",
+                    "sms:displayName": "dataType",
+                    "rdfs:comment": "The type of data"
+                }
+            ]
+        }
+        mock_load_jsonld.return_value = mock_jsonld_data
+
+        tool = CreateAnnotationTemplateCSVTool()
+        attributes = tool._get_template_attributes(mock_jsonld_data, "RNASeqTemplate")
+
+        expected_attributes = [
+            {"id": "bts:Assay", "label": "assay", "description": "The type of assay"},
+            {"id": "bts:DataType", "label": "dataType", "description": "The type of data"}
+        ]
+
+        self.assertEqual(attributes, expected_attributes)
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/tests/tools/test_zooma_tools.py
+++ b/tests/tools/test_zooma_tools.py
@@ -1,0 +1,84 @@
+import pytest
+import json
+from unittest.mock import Mock
+from src.tools.zooma_tools import ZoomaTermMappingTool, _extract_short_uri
+
+@pytest.fixture
+def zooma_tool():
+    """Fixture to create an instance of the ZoomaTermMappingTool."""
+    return ZoomaTermMappingTool()
+
+@pytest.fixture
+def mock_requests_get(mocker):
+    """Fixture to mock requests.get."""
+    return mocker.patch('requests.get')
+
+# Mock API response for "plexiform neurofibroma"
+mock_neurofibroma_response = [
+    {
+        "semanticTags": ["http://purl.obolibrary.org/obo/NCIT_C3797"],
+        "derivedFrom": {
+            "annotatedProperty": {
+                "propertyValue": "Plexiform Neurofibroma"
+            }
+        }
+    }
+]
+
+def test_extract_short_uri():
+    """Test the URI extraction helper function."""
+    assert _extract_short_uri("http://purl.obolibrary.org/obo/NCIT_C3797") == "NCIT_C3797"
+    assert _extract_short_uri("http://a/b/c/D") == "D"
+    assert _extract_short_uri("E") == "E"
+
+def test_run_success(zooma_tool, mock_requests_get):
+    """Test successful run returns a JSON object with term and URI."""
+    # Arrange
+    mock_response = Mock()
+    mock_response.json.return_value = mock_neurofibroma_response
+    mock_response.raise_for_status.return_value = None
+    mock_requests_get.return_value = mock_response
+
+    # Act
+    result_json = zooma_tool._run(query="plexiform neurofibroma")
+    result = json.loads(result_json)
+
+    # Assert
+    assert result == {"term": "Plexiform Neurofibroma", "uri": "NCIT_C3797"}
+    mock_requests_get.assert_called_once_with(
+        "http://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate",
+        params={"propertyValue": "plexiform neurofibroma"}
+    )
+
+def test_run_no_results(zooma_tool, mock_requests_get):
+    """Test that an empty API response returns a JSON error."""
+    # Arrange
+    mock_response = Mock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status.return_value = None
+    mock_requests_get.return_value = mock_response
+
+    # Act
+    result_json = zooma_tool._run(query="some rare term")
+    result = json.loads(result_json)
+
+    # Assert
+    assert "error" in result
+    assert result["error"] == "No ontology term found for the given query."
+
+def test_run_malformed_response(zooma_tool, mock_requests_get):
+    """Test that a malformed API response returns a JSON error."""
+    # Arrange
+    malformed_response = [{"confidence": "HIGH"}]  # Missing 'derivedFrom'
+    mock_response = Mock()
+    mock_response.json.return_value = malformed_response
+    mock_response.raise_for_status.return_value = None
+    mock_requests_get.return_value = mock_response
+
+    # Act
+    result_json = zooma_tool._run(query="test")
+    result = json.loads(result_json)
+
+    # Assert
+    assert "error" in result
+    assert result["error"] == "Could not extract term or URI from the API response." 

--- a/tests/utils/test_synapse_utils.py
+++ b/tests/utils/test_synapse_utils.py
@@ -1,0 +1,78 @@
+import unittest
+import synapseclient
+from synapseclient import Project, Schema, Column, Table, RowSet
+import pandas as pd
+import uuid
+from src.utils.synapse_utils import update_table_column_with_corrections
+
+class TestSynapseUtilsIntegration(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Sets up a real Synapse project and table for integration testing.
+        """
+        self.syn = synapseclient.login()
+        self.project_name = f"Test Project - {uuid.uuid4()}"
+        self.project = self.syn.store(Project(name=self.project_name))
+
+        # Define table schema
+        self.column_name = "resourceType"
+        cols = [
+            Column(name=self.column_name, columnType='STRING', maximumSize=50),
+            Column(name='another_col', columnType='INTEGER'),
+        ]
+        schema = self.syn.store(Schema(name="Test Table", columns=cols, parent=self.project))
+
+        # Initial data
+        self.initial_data = [
+            ['dataset', 10],
+            ['analysis', 20],
+            ['processed', 30],
+            [None, 40]
+        ]
+        self.table = self.syn.store(Table(schema, self.initial_data))
+        self.table_id = self.table.schema.id
+
+    def tearDown(self):
+        """
+        Deletes the Synapse project created for testing.
+        """
+        if hasattr(self, 'project'):
+            self.syn.delete(self.project)
+        
+    def test_update_table_integration(self):
+        """
+        Tests the update_table_column_with_corrections function against a real Synapse table.
+        """
+        # 1. Define the corrections. Per user feedback, None values should not be changed.
+        corrections = [
+            {'current_value': 'dataset', 'new_value': 'Data Set'},
+            {'current_value': 'analysis', 'new_value': 'result'},
+            {'current_value': 'processed', 'new_value': 'processed data'}
+        ]
+
+        # 2. Run the function to be tested
+        update_table_column_with_corrections(self.syn, self.table_id, self.column_name, corrections)
+
+        # 3. Verify the changes
+        
+        # Query the table to get the updated data
+        results = self.syn.tableQuery(f"SELECT {self.column_name}, another_col FROM {self.table_id}")
+        updated_df = results.asDataFrame(convert_to_datetime=True)
+
+        # Create the expected DataFrame. The None value should remain.
+        expected_data = {
+            self.column_name: ['Data Set', 'result', 'processed data', None],
+            'another_col': [10, 20, 30, 40]
+        }
+        expected_df = pd.DataFrame(expected_data)
+
+        # Sort both dataframes to ensure comparison is not affected by row order
+        updated_df_sorted = updated_df.sort_values(by=['another_col']).reset_index(drop=True)
+        expected_df_sorted = expected_df.sort_values(by=['another_col']).reset_index(drop=True)
+        
+        # Use pandas testing utility to compare the dataframes
+        pd.testing.assert_frame_equal(updated_df_sorted, expected_df_sorted)
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
Fixes [SEC-489](https://sagebionetworks.jira.com/browse/SEC-489).

Two commits: the security fix, then the module restore that makes it verifiable.

---

# 1. SEC-489 — dependency remediation (`dedbcc52`)

## Root cause

The 29 findings were not vendored code. `requirements.txt` was **fully unpinned**, and osv-scanner resolves the *lowest* version satisfying each lower bound. crewai's loose constraints therefore resolved to `pillow 9.5.0`, `chromadb 1.1.1`, `json-repair 0.25.2` — versions that exist in **no branch** of this repo. Reproducing the scan against a pinned tree recreated the ticket's table exactly.

Pinning makes resolution deterministic and the dependency tree actually auditable.

## Result

| | Before | After |
|---|---:|---:|
| CRITICAL/HIGH | 19 | **1** |

| Package | Before | After | Cleared |
|---|---|---|---|
| pillow | 9.5.0 | 12.3.0 | 1 CRITICAL + 13 HIGH |
| json-repair | 0.25.2 | 0.60.1 | 1 HIGH |
| urllib3 | 2.6.3 | 2.7.0 | 4 HIGH |
| python-multipart | 0.0.9 | 0.0.32 | 4 HIGH |

## Not fixable: chromadb

`CVE-2026-45829` (CRITICAL, `GHSA-f4j7-r4q5-qw2c`) has **no fixed release in any chromadb version** (checked through 1.5.9), and crewai caps chromadb at `~=1.1.0`. Needs risk acceptance, not a version bump. Documented inline in `requirements.txt`.

## Behaviour change: CodeInterpreterTool removed

Fixing json-repair requires crewai >= 1.15.6 — every earlier release hard-pins `json-repair==0.25.2`. crewai removed `CodeInterpreterTool` in 1.14.0 (upstream recommends dedicated sandbox services) and `crewai_tools` no longer exports it, so the existing import would fail outright on any 1.15.x.

Dropped from both call sites. The agent retains `SynapsePythonCodeExecutorTool`, the project's own Synapse-aware executor, so code-execution capability is preserved. The agent backstory, which still named the Code Interpreter Tool, was repointed at the executor so the prompt matches the tools actually wired up.

Staying on crewai 1.13.0 to keep the tool was measured and left **5** CRITICAL/HIGH (chromadb, json-repair, 3× `mcp` locked by `mcp~=1.26.0`), so it was rejected.

---

# 2. Restore missing modules (`927af732`)

`main` could not be imported at all. `src/agents/__init__.py` and `src/tools/__init__.py` reference modules that were never committed, so `import src.agents` failed immediately. This lands them, which is also what makes the crewai upgrade above verifiable rather than assumed.

`src/agents/__init__.py` additionally imported `sync_external_metadata`, which **has never existed in any commit, any branch, or the stash**. That import is dropped.

Restored: `ontology_expert`, `pride_sync_agent`, `synapse_agent`, `geo_tools`, `pride_tools`, `sra_tools`, `zooma_tools`, `bioregistry_tools`, `human_tools`, `jsonld_utils`, `cli_utils`, `synapse_utils`, `annotation_utils`, plus 3 test modules.

## Undeclared dependencies

Two more packages were imported but never declared, so a clean install had no way to get them:

- **`GEOparse`** — required by `src/tools/geo_tools.py`
- **`pytest-mock`** — provides the `mocker` fixture used by `test_zooma_tools.py`

`pandas` was the same story and is fixed in commit 1: six source files import it, but it only ever arrived transitively via crewai-tools 0.x, which the new tree no longer pulls.

Test-only dependencies now live in `requirements-dev.txt` so the runtime surface that gets vulnerability-scanned stays limited to what actually ships.

---

# Verification

Clean venv against the pinned requirements:

```
pip install -r requirements.txt -r requirements-dev.txt   exit 0
all 8 agent factories construct on crewai 1.15.14         8 OK, 0 FAIL
Crew assembles; link_external_data wires 14 tools         OK
pytest                                                    6 passed
osv-scanner                                               1 CRITICAL/HIGH (chromadb)
OSV audit of full resolved tree                           2 advisories, 1 CRITICAL/HIGH
```

`CodeInterpreterTool` turned out to be the only crewai 1.x removal affecting this codebase. The rest of the migration is clean apart from a deprecation warning on `function_calling_llm`.

# Known remaining issue

`src/tools/synapse_analysis_tools.py:19` uses `from jsonld_tools import ...` instead of `from src.tools.jsonld_tools import ...`. It is inside a function so it does not break import, but it will fail when that path is hit. Left alone as it is unrelated to this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBkNC5TXfvZiKv5JuQvijU